### PR TITLE
Define xrange() for Python 3

### DIFF
--- a/tcav.py
+++ b/tcav.py
@@ -28,6 +28,11 @@ import run_params
 import tensorflow as tf
 import utils
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 
 class TCAV(object):
   """TCAV object: runs TCAV for one target and a set of concepts.


### PR DESCRIPTION
See #1 __xrange()__ was remove in Python 3 in favor of __range()__.