### PR TITLE
remove reliance on random500_* concepts

### DIFF
--- a/tcav_test.py
+++ b/tcav_test.py
@@ -121,6 +121,28 @@ class TcavTest(googletest.TestCase):
                             ('t1',['random500_1', 'random500_2'])
                            ]))
 
+  def test__process_what_to_run_expand_specify_dirs(self):
+    # _process_what_to_run_expand stores results to all_concepts,
+    # and pairs_to_test.
+    self.mytcav._process_what_to_run_expand(
+        num_random_exp=2, random_dirs=['random_dir1', 'random_dir2'])
+    self.assertEqual(sorted(self.mytcav.all_concepts),
+                     sorted(['t1',
+                             'c1',
+                             'c2',
+                             'random500_1',
+                             'random_dir1',
+                             'random_dir2'])
+                    )
+    self.assertEqual(sorted(self.mytcav.pairs_to_test),
+                    sorted([('t1',['c1', 'random_dir1']),
+                            ('t1',['c1', 'random_dir2']),
+                            ('t1',['c2', 'random_dir1']),
+                            ('t1',['c2', 'random_dir2']),
+                            ('t1',['random500_1', 'random_dir1']),
+                            ('t1',['random500_1', 'random_dir2'])
+                           ]))
+
   def test_get_params(self):
     """Check if the first param was correct.
     """

--- a/utils.py
+++ b/utils.py
@@ -47,25 +47,31 @@ def flatten(nested_list):
 
 def process_what_to_run_expand(pairs_to_test,
                                random_counterpart,
-                               num_random_exp=100):
+                               num_random_exp=100,
+                               random_dirs=None):
   """Get concept vs. random or random vs. random pairs to run.
 
     Given set of target, list of concept pairs, expand them to include
      random pairs. For instance [(t1, [c1, c2])...] becomes
-     [(t1, [c1, random500_1],
-      (t1, [c1, random500_2],...
-      (t1, [c2, random500_1],
-      (t1, [c2, random500_2],...]
+     [(t1, [c1, random1],
+      (t1, [c1, random2],...
+      (t1, [c2, random1],
+      (t1, [c2, random2],...]
 
   Args:
     pairs_to_test: [(target, [concept1, concept2,...]),...]
     random_counterpart: random concept that will be compared to the concept.
     num_random_exp: number of random experiments to run against each concept.
+    random_dirs: A list of names of random concepts for the random experiments
+                 to draw from. Optional, if not provided, the names will be
+                 random500_{i} for i in num_random_exp.
 
   Returns:
     all_concepts: unique set of targets/concepts
     new_pairs_to_test: expanded
   """
+  def get_random_concept(i):
+    return random_dirs[i] if random_dirs else 'random500_{}'.format(i)
 
   new_pairs_to_test = []
   for (target, concept_set) in pairs_to_test:
@@ -75,10 +81,10 @@ def process_what_to_run_expand(pairs_to_test,
       i = 0
       while len(new_pairs_to_test_t) < min(100, num_random_exp):
         # make sure that we are not comparing the same thing to each other.
-        if concept_set[0] != 'random500_{}'.format(
-            i) and random_counterpart != 'random500_{}'.format(i):
+        if concept_set[0] != get_random_concept(
+           i) and random_counterpart != get_random_concept(i):
           new_pairs_to_test_t.append(
-              (target, [concept_set[0], 'random500_{}'.format(i)]))
+              (target, [concept_set[0], get_random_concept(i)]))
         i += 1
     elif len(concept_set) > 1:
       new_pairs_to_test_t.append((target, concept_set))
@@ -127,8 +133,8 @@ def process_what_to_run_randoms(pairs_to_test, random_counterpart):
 
   Returns:
     return pairs to test:
-          target1, random500_1,
-          target2, random500_1,
+          target1, random_counterpart,
+          target2, random_counterpart,
           ...
   """
   # prepare pairs for random vs random.

--- a/utils_test.py
+++ b/utils_test.py
@@ -34,7 +34,6 @@ class UtilsTest(googletest.TestCase):
         self.pair_to_test_one_concept,
         self.random_counterpart,
         num_random_exp=2)
-    print(pairs_to_test)
     self.assertEqual(
         sorted(all_concepts),
         sorted(['t1', 'c1', 'random500_2', 'random500_1', 'random500_0']))
@@ -43,6 +42,21 @@ class UtilsTest(googletest.TestCase):
         sorted([('t1', ['c1', 'random500_0']), ('t1', ['c1', 'random500_2']),
                 ('t1', ['random500_1', 'random500_0']),
                 ('t1', ['random500_1', 'random500_2'])]))
+
+  def test_process_what_to_run_expand_specify_dirs(self):
+    all_concepts, pairs_to_test = process_what_to_run_expand(
+        self.pair_to_test_one_concept,
+        self.random_counterpart,
+        num_random_exp=2,
+        random_dirs=['random_dir1', 'random_dir2'])
+    self.assertEqual(
+        sorted(all_concepts),
+        sorted(['t1', 'c1', 'random500_1', 'random_dir1', 'random_dir2']))
+    self.assertEqual(
+        sorted(pairs_to_test),
+        sorted([('t1', ['c1', 'random_dir1']), ('t1', ['c1', 'random_dir2']),
+                ('t1', ['random500_1', 'random_dir1']),
+                ('t1', ['random500_1', 'random_dir2'])]))
 
   def test_process_what_to_run_concepts(self):
     self.assertEqual(


### PR DESCRIPTION
TCAV constructor now takes an optional list of random concepts to use for random experiments, removing dependence on random500_* directories. If the list is None (which is the default), then it still uses the random500_* dirs, for backwards compatibility.