### PR TITLE
Undefined name: Define xrange() in Python 3

### DIFF
--- a/cav_test.py
+++ b/cav_test.py
@@ -24,6 +24,11 @@ from tensorflow.python.platform import flags
 from tensorflow.python.platform import googletest
 from cav import CAV, get_or_train_cav
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 FLAGS = flags.FLAGS
 flags.DEFINE_string(name='test_tmpdir', default='/tmp',
                     help='Temporary directory for test files')


### PR DESCRIPTION
__xrange()__ was removed in Python 3 in favor of __range()__.