### PR TITLE
Use explicit file opening modes

### DIFF
--- a/cav.py
+++ b/cav.py
@@ -55,7 +55,7 @@ class CAV(object):
     Returns:
       CAV instance.
     """
-    with tf.gfile.Open(cav_path) as pkl_file:
+    with tf.gfile.Open(cav_path, 'rb') as pkl_file:
       save_dict = pickle.load(pkl_file)
 
     cav = CAV(save_dict['concepts'], save_dict['bottleneck'],

--- a/model.py
+++ b/model.py
@@ -146,7 +146,7 @@ class PublicModelWrapper(ModelWrapper):
                image_shape,
                endpoints_dict,
                scope):
-    self.labels = tf.gfile.Open(labels_path).read().splitlines()
+    self.labels = tf.gfile.Open(labels_path, 'r').read().splitlines()
     self.ends = PublicModelWrapper.import_graph(model_fn_path,
                                                 image_shape,
                                                 endpoints_dict,
@@ -215,7 +215,7 @@ class PublicModelWrapper(ModelWrapper):
         'Scope "%s" already exists. Provide explicit scope names when '
         'importing multiple instances of the model.') % scope
 
-    graph_def = tf.GraphDef.FromString(tf.gfile.Open(saved_path).read())
+    graph_def = tf.GraphDef.FromString(tf.gfile.Open(saved_path, 'rb').read())
 
     with tf.name_scope(scope) as sc:
       t_input, t_prep_input = PublicModelWrapper.create_input(t_input, image_shape, image_value_range)

--- a/tcav_helpers.py
+++ b/tcav_helpers.py
@@ -88,7 +88,7 @@ def load_image_from_file(filename, shape):
     tf.logging.error('Cannot find file: {}'.format(filename))
     return None
   try:
-    img = np.array(PIL.Image.open(tf.gfile.Open(filename)).resize(
+    img = np.array(PIL.Image.open(tf.gfile.Open(filename, 'rb')).resize(
         shape, PIL.Image.BILINEAR))
     # Normalize pixel values to between 0 and 1.
     img = np.float32(img) / 255.0
@@ -249,7 +249,7 @@ def process_and_load_activations(model, bottleneck_names, concepts,
                                max_images=max_images)
 
       if bottleneck_name not in acts[concept].keys():
-        with tf.gfile.Open(acts_path) as f:
+        with tf.gfile.Open(acts_path, 'rb') as f:
           acts[concept][bottleneck_name] = np.load(f).squeeze()
           tf.logging.info('Loaded {} shape {}'.format(
               acts_path,


### PR DESCRIPTION
Had a few issues getting tcav running on Python 3 – one of the issues was of the form:

```
'utf-8' codec can't decode byte 0x89 in position 0: invalid start byte
```

This was due to Python interpreting some files as text when they were binary.

In this commit I've just added an explicit `r` or `rb` to each `Open()` which fixes the problem and should work in both Python 2 and 3.