### PR TITLE
Changes to random concept calculation and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ mytcav = tcav.TCAV(sess,
                    bottlenecks,
                    act_gen,
                    alphas,
-                   random_counterpart,
                    cav_dir=cav_dir,
                    num_random_exp=2)
 

--- a/Run TCAV.ipynb
+++ b/Run TCAV.ipynb
@@ -43,6 +43,7 @@
     "import model  as model\n",
     "import tcav as tcav\n",
     "import utils as utils\n",
+    "import utils_plot as utils_plot # utils_plot requires matplotlib\n",
     "import os \n",
     "import activation_generator as act_gen\n",
     "import tensorflow as tf"
@@ -237,7 +238,9 @@
     "\n",
     "Let's do it.\n",
     "\n",
-    "**num_random_exp**: number of experiments to confirm meaningful concept direction. Run at least 10-20 for meaningful tests. \n"
+    "**num_random_exp**: number of experiments to confirm meaningful concept direction. TCAV will search for this many folders named `random500_0`, `random500_1`, etc. You can alternatively set the `random_concepts` keyword to be a list of folders of random concepts. Run at least 10-20 for meaningful tests. \n",
+    "\n",
+    "**random_counterpart**: as well as the above, you can optionally supply a single folder with random images as the \"positive set\" for statistical testing. Reduces computation time at the cost of less reliable random TCAV scores. \n"
    ]
   },
   {
@@ -268,7 +271,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "utils.print_results(results, output_plot=True, num_random_exp=10)"
+    "utils_plot.plot_results(results, num_random_exp=10)"
    ]
   }
  ],

--- a/Run TCAV.ipynb
+++ b/Run TCAV.ipynb
@@ -99,8 +99,6 @@
     "\n",
     "# this is a regularizer penalty parameter for linear classifier to get CAVs. \n",
     "alphas = [0.1]   \n",
-    "# a folder that random images are stored\n",
-    "random_counterpart = 'random500_1'\n",
     "\n",
     "target = 'zebra'  \n",
     "concepts = [\"dotted\",\"striped\",\"zigzagged\"]   \n"
@@ -258,7 +256,6 @@
     "                   bottlenecks,\n",
     "                   act_generator,\n",
     "                   alphas,\n",
-    "                   random_counterpart,\n",
     "                   cav_dir=cav_dir,\n",
     "                   num_random_exp=10)\n",
     "\n",
@@ -271,7 +268,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "utils.print_results(results)"
+    "utils.print_results(results, output_plot=True, num_random_exp=10)"
    ]
   }
  ],

--- a/activation_generator.py
+++ b/activation_generator.py
@@ -121,8 +121,9 @@ class ImageActivationGenerator(ActivationGeneratorBase):
       tf.logging.error('Cannot find file: {}'.format(filename))
       return None
     try:
-      img = np.array(PIL.Image.open(tf.gfile.Open(filename)).resize(
-          shape, PIL.Image.BILINEAR))
+      # ensure image has no transparency channel
+      img = np.array(PIL.Image.open(tf.gfile.Open(filename, 'rb')).convert(
+          'RGB').resize(shape, PIL.Image.BILINEAR))
       # Normalize pixel values to between 0 and 1.
       img = np.float32(img) / 255.0
       if not (len(img.shape) == 3 and img.shape[2] == 3):
@@ -165,13 +166,16 @@ class ImageActivationGenerator(ActivationGeneratorBase):
           lambda filename: self.load_image_from_file(filename, shape),
           filenames[:max_imgs])
       imgs = [img for img in imgs if img is not None]
+      if len(imgs) <= 1:
+        raise ValueError('You must have more than 1 image in each class to run TCAV.')
     else:
       for filename in filenames:
         img = self.load_image_from_file(filename, shape)
         if img is not None:
           imgs.append(img)
-        if len(imgs) >= max_imgs:
+        if len(imgs) <= 1:
+          raise ValueError('You must have more than 1 image in each class to run TCAV.')
+        elif len(imgs) >= max_imgs:
           break
 
     return np.array(imgs)
-

--- a/activation_generator.py
+++ b/activation_generator.py
@@ -73,7 +73,7 @@ class ActivationGeneratorBase(ActivationGeneratorInterface):
         acts_path = os.path.join(self.acts_dir, 'acts_{}_{}'.format(
             concept, bottleneck_name)) if self.acts_dir else None
         if acts_path and tf.gfile.Exists(acts_path):
-          with tf.gfile.Open(acts_path) as f:
+          with tf.gfile.Open(acts_path, 'rb') as f:
             acts[concept][bottleneck_name] = np.load(f).squeeze()
             tf.logging.info('Loaded {} shape {}'.format(
                 acts_path, acts[concept][bottleneck_name].shape))

--- a/cav.py
+++ b/cav.py
@@ -55,7 +55,7 @@ class CAV(object):
     Returns:
       CAV instance.
     """
-    with tf.gfile.Open(cav_path) as pkl_file:
+    with tf.gfile.Open(cav_path, 'rb') as pkl_file:
       save_dict = pickle.load(pkl_file)
 
     cav = CAV(save_dict['concepts'], save_dict['bottleneck'],

--- a/cav_test.py
+++ b/cav_test.py
@@ -23,6 +23,7 @@ from sklearn import linear_model
 from tensorflow.python.platform import flags
 from tensorflow.python.platform import googletest
 from cav import CAV, get_or_train_cav
+from tcav import xrange
 
 FLAGS = flags.FLAGS
 flags.DEFINE_string(name='test_tmpdir', default='/tmp',

--- a/tcav.py
+++ b/tcav.py
@@ -294,12 +294,17 @@ class TCAV(object):
     pairs_to_run_randoms = []
     all_concepts_randoms = []
 
+    # ith random concept
+    def get_random_concept(i):
+      return (random_concepts[i] if random_concepts
+              else 'random500_{}'.format(i))
+
     # TODO random500_1 vs random500_0 is the same as 1 - (random500_0 vs random500_1)
-    for i in range(num_random_exp):
+    for i in xrange(num_random_exp):
       all_concepts_randoms_tmp, pairs_to_run_randoms_tmp = (
           utils.process_what_to_run_expand(
               utils.process_what_to_run_randoms(target_concept_pairs,
-                                                'random500_{}'.format(i)),
+                                                get_random_concept(i)),
               num_random_exp=num_random_exp - 1,
               random_concepts=random_concepts))
 

--- a/tcav.py
+++ b/tcav.py
@@ -195,7 +195,8 @@ class TCAV(object):
       results = pool.map(lambda param: self._run_single_set(param), self.params)
     else:
       results = []
-      for param in self.params:
+      for i, param in enumerate(self.params):
+        tf.logging.info('Running param %s of %s' % (i, len(self.params)))
         results.append(self._run_single_set(param))
     tf.logging.info('Done running %s params. Took %s seconds...' % (len(
         self.params), time.time() - now))

--- a/tcav.py
+++ b/tcav.py
@@ -136,7 +136,6 @@ class TCAV(object):
                bottlenecks,
                activation_generator,
                alphas,
-               random_counterpart,
                cav_dir=None,
                num_random_exp=5,
                random_concepts=None):
@@ -150,8 +149,6 @@ class TCAV(object):
       activation_generator: an ActivationGeneratorInterface instance to return
                             activations.
       alphas: list of hyper parameters to run
-      random_counterpart: the random concept to run against the concepts for
-                          statistical testing.
       cav_dir: the path to store CAVs
       num_random_exp: number of random experiments to compare against.
       random_concepts: A list of names of random concepts for the random
@@ -164,7 +161,6 @@ class TCAV(object):
     self.activation_generator = activation_generator
     self.cav_dir = cav_dir
     self.alphas = alphas
-    self.random_counterpart = random_counterpart
     self.mymodel = activation_generator.get_model()
     self.model_to_run = self.mymodel.model_name
     self.sess = sess
@@ -292,19 +288,18 @@ class TCAV(object):
     all_concepts_concepts, pairs_to_run_concepts = (
         utils.process_what_to_run_expand(
             utils.process_what_to_run_concepts(target_concept_pairs),
-            self.random_counterpart,
             num_random_exp=num_random_exp,
             random_concepts=random_concepts))
 
     pairs_to_run_randoms = []
     all_concepts_randoms = []
 
+    # TODO random500_1 vs random500_0 is the same as 1 - (random500_0 vs random500_1)
     for i in range(num_random_exp):
       all_concepts_randoms_tmp, pairs_to_run_randoms_tmp = (
           utils.process_what_to_run_expand(
               utils.process_what_to_run_randoms(target_concept_pairs,
                                                 'random500_{}'.format(i)),
-              self.random_counterpart,
               num_random_exp=num_random_exp - 1,
               random_concepts=random_concepts))
 

--- a/tcav.py
+++ b/tcav.py
@@ -165,6 +165,9 @@ class TCAV(object):
     self.model_to_run = self.mymodel.model_name
     self.sess = sess
 
+    if random_concepts:
+      num_random_exp = len(random_concepts)
+
     # make pairs to test.
     self._process_what_to_run_expand(num_random_exp=num_random_exp,
                                      random_concepts=random_concepts)

--- a/tcav.py
+++ b/tcav.py
@@ -240,36 +240,36 @@ class TCAV(object):
                             cav_hparams.alpha)
     target_class_for_compute_tcav_score = target_class
 
-    for cav_concept in concepts:
-      if cav_concept is self.random_counterpart or 'random' not in cav_concept:
-        i_up = self.compute_tcav_score(
-            mymodel, target_class_for_compute_tcav_score, cav_concept,
-            cav_instance, acts[target_class][cav_instance.bottleneck])
-        val_directional_dirs = self.get_directional_dir(
-            mymodel, target_class_for_compute_tcav_score, cav_concept,
-            cav_instance, acts[target_class][cav_instance.bottleneck])
-        result = {
-            'cav_key':
-                a_cav_key,
-            'cav_concept':
-                cav_concept,
-            'target_class':
-                target_class,
-            'i_up':
-                i_up,
-            'val_directional_dirs_abs_mean':
-                np.mean(np.abs(val_directional_dirs)),
-            'val_directional_dirs_mean':
-                np.mean(val_directional_dirs),
-            'val_directional_dirs_std':
-                np.std(val_directional_dirs),
-            'note':
-                'alpha_%s ' % (alpha),
-            'alpha':
-                alpha,
-            'bottleneck':
-                bottleneck
-        }
+    cav_concept = concepts[0]
+
+    i_up = self.compute_tcav_score(
+        mymodel, target_class_for_compute_tcav_score, cav_concept,
+        cav_instance, acts[target_class][cav_instance.bottleneck])
+    val_directional_dirs = self.get_directional_dir(
+        mymodel, target_class_for_compute_tcav_score, cav_concept,
+        cav_instance, acts[target_class][cav_instance.bottleneck])
+    result = {
+        'cav_key':
+            a_cav_key,
+        'cav_concept':
+            cav_concept,
+        'target_class':
+            target_class,
+        'i_up':
+            i_up,
+        'val_directional_dirs_abs_mean':
+            np.mean(np.abs(val_directional_dirs)),
+        'val_directional_dirs_mean':
+            np.mean(val_directional_dirs),
+        'val_directional_dirs_std':
+            np.std(val_directional_dirs),
+        'note':
+            'alpha_%s ' % (alpha),
+        'alpha':
+            alpha,
+        'bottleneck':
+            bottleneck
+    }
     del acts
     return result
 
@@ -295,13 +295,22 @@ class TCAV(object):
             self.random_counterpart,
             num_random_exp=num_random_exp,
             random_concepts=random_concepts))
-    all_concepts_randoms, pairs_to_run_randoms = (
-        utils.process_what_to_run_expand(
-            utils.process_what_to_run_randoms(target_concept_pairs,
-                                              self.random_counterpart),
-            self.random_counterpart,
-            num_random_exp=num_random_exp,
-            random_concepts=random_concepts))
+
+    pairs_to_run_randoms = []
+    all_concepts_randoms = []
+
+    for i in range(num_random_exp):
+      all_concepts_randoms_tmp, pairs_to_run_randoms_tmp = (
+          utils.process_what_to_run_expand(
+              utils.process_what_to_run_randoms(target_concept_pairs,
+                                                'random500_{}'.format(i)),
+              self.random_counterpart,
+              num_random_exp=num_random_exp - 1,
+              random_concepts=random_concepts))
+
+      pairs_to_run_randoms.extend(pairs_to_run_randoms_tmp)
+      all_concepts_randoms.extend(all_concepts_randoms_tmp)
+
     self.all_concepts = list(set(all_concepts_concepts + all_concepts_randoms))
     self.pairs_to_test = pairs_to_run_concepts + pairs_to_run_randoms
 

--- a/tcav_test.py
+++ b/tcav_test.py
@@ -69,6 +69,7 @@ class TcavTest(googletest.TestCase):
     self.activation_generator = None
     self.mymodel = TcavTest_model()
     self.act_gen = TcavTest_ActGen(self.mymodel)
+    self.random_counterpart = 'random500_1'
 
     self.mytcav = TCAV(None,
                        self.target,
@@ -76,6 +77,14 @@ class TcavTest(googletest.TestCase):
                        [self.bottleneck],
                        self.act_gen,
                        [self.hparams.alpha])
+
+    self.mytcav_random_counterpart = TCAV(None,
+                                          self.target,
+                                          self.concepts,
+                                          [self.bottleneck],
+                                          self.act_gen,
+                                          [self.hparams.alpha],
+                                          self.random_counterpart)
 
   def test_get_direction_dir_sign(self):
     self.assertFalse(TCAV.get_direction_dir_sign(self.mymodel,
@@ -128,6 +137,29 @@ class TcavTest(googletest.TestCase):
                             ('t1',['random500_1', 'random500_0'])
                            ]))
 
+  def test__process_what_to_run_expand_random_counterpart(self):
+    # _process_what_to_run_expand stores results to all_concepts,
+    # and pairs_to_test.
+    # test when random_counterpart is supplied
+    self.mytcav_random_counterpart._process_what_to_run_expand(
+        num_random_exp=2)
+    self.assertEqual(sorted(self.mytcav_random_counterpart.all_concepts),
+                     sorted(['t1',
+                             'c1',
+                             'c2',
+                             'random500_0',
+                             'random500_1',
+                             'random500_2'])
+                    )
+    self.assertEqual(sorted(self.mytcav_random_counterpart.pairs_to_test),
+                    sorted([('t1',['c1', 'random500_0']),
+                            ('t1',['c1', 'random500_2']),
+                            ('t1',['c2', 'random500_0']),
+                            ('t1',['c2', 'random500_2']),
+                            ('t1',['random500_1', 'random500_0']),
+                            ('t1',['random500_1', 'random500_2'])
+                           ]))
+
   def test__process_what_to_run_expand_specify_dirs(self):
     # _process_what_to_run_expand stores results to all_concepts,
     # and pairs_to_test.
@@ -147,6 +179,29 @@ class TcavTest(googletest.TestCase):
                             ('t1',['c2', 'random_dir2']),
                             ('t1',['random_dir1', 'random_dir2']),
                             ('t1',['random_dir2', 'random_dir1'])
+                           ]))
+
+  def test__process_what_to_run_expand_specify_dirs_random_concepts(self):
+    # _process_what_to_run_expand stores results to all_concepts,
+    # and pairs_to_test.
+    # test when random_counterpart is supplied
+    self.mytcav_random_counterpart._process_what_to_run_expand(
+        num_random_exp=2, random_concepts=['random_dir1', 'random_dir2'])
+    self.assertEqual(sorted(self.mytcav_random_counterpart.all_concepts),
+                     sorted(['t1',
+                             'c1',
+                             'c2',
+                             'random500_1',
+                             'random_dir1',
+                             'random_dir2'])
+                    )
+    self.assertEqual(sorted(self.mytcav_random_counterpart.pairs_to_test),
+                    sorted([('t1',['c1', 'random_dir1']),
+                            ('t1',['c1', 'random_dir2']),
+                            ('t1',['c2', 'random_dir1']),
+                            ('t1',['c2', 'random_dir2']),
+                            ('t1',['random500_1', 'random_dir1']),
+                            ('t1',['random500_1', 'random_dir2'])
                            ]))
 
   def test_get_params(self):

--- a/tcav_test.py
+++ b/tcav_test.py
@@ -66,7 +66,6 @@ class TcavTest(googletest.TestCase):
                        self.bottleneck,
                        self.hparams)
     self.cav.cavs = [[1., 2., 3.,]]
-    self.random_counterpart = 'random500_1'
     self.activation_generator = None
     self.mymodel = TcavTest_model()
     self.act_gen = TcavTest_ActGen(self.mymodel)
@@ -76,8 +75,7 @@ class TcavTest(googletest.TestCase):
                        self.concepts,
                        [self.bottleneck],
                        self.act_gen,
-                       [self.hparams.alpha],
-                       self.random_counterpart)
+                       [self.hparams.alpha])
 
   def test_get_direction_dir_sign(self):
     self.assertFalse(TCAV.get_direction_dir_sign(self.mymodel,

--- a/tcav_test.py
+++ b/tcav_test.py
@@ -117,16 +117,15 @@ class TcavTest(googletest.TestCase):
                              'c1',
                              'c2',
                              'random500_0',
-                             'random500_1',
-                             'random500_2'])
+                             'random500_1'])
                     )
     self.assertEqual(sorted(self.mytcav.pairs_to_test),
                     sorted([('t1',['c1', 'random500_0']),
-                            ('t1',['c1', 'random500_2']),
+                            ('t1',['c1', 'random500_1']),
                             ('t1',['c2', 'random500_0']),
-                            ('t1',['c2', 'random500_2']),
-                            ('t1',['random500_1', 'random500_0']),
-                            ('t1',['random500_1', 'random500_2'])
+                            ('t1',['c2', 'random500_1']),
+                            ('t1',['random500_0', 'random500_1']),
+                            ('t1',['random500_1', 'random500_0'])
                            ]))
 
   def test__process_what_to_run_expand_specify_dirs(self):
@@ -138,7 +137,6 @@ class TcavTest(googletest.TestCase):
                      sorted(['t1',
                              'c1',
                              'c2',
-                             'random500_1',
                              'random_dir1',
                              'random_dir2'])
                     )
@@ -147,8 +145,8 @@ class TcavTest(googletest.TestCase):
                             ('t1',['c1', 'random_dir2']),
                             ('t1',['c2', 'random_dir1']),
                             ('t1',['c2', 'random_dir2']),
-                            ('t1',['random500_1', 'random_dir1']),
-                            ('t1',['random500_1', 'random_dir2'])
+                            ('t1',['random_dir1', 'random_dir2']),
+                            ('t1',['random_dir2', 'random_dir1'])
                            ]))
 
   def test_get_params(self):

--- a/utils.py
+++ b/utils.py
@@ -174,7 +174,7 @@ def print_results(results):
 
 # function to output all results both in a printed format, and in a 
 # matplotlib graph when in interactive mode
-def print_results_graph(results, min_p_val):
+def print_results_graph(results, min_p_val, num_random_exp):
   """Helper function to organize results.
   When run in a notebook, outputs a matplotlib bar plot of the
   TCAV scores for all bottlenecks for each concept, replacing the
@@ -204,19 +204,20 @@ def print_results_graph(results, min_p_val):
     result_summary[result['cav_concept']][result['bottleneck']].append(result)
     
     # store random
-    if result['cav_concept'] == 'random':
+    #TODO use random_concepts
+    if 'random500_' in result['cav_concept']:
       if result['bottleneck'] not in random_i_ups:
         random_i_ups[result['bottleneck']] = []
         
       random_i_ups[result['bottleneck']].append(result['i_up'])
     
   # to plot, must massage data again 
-  fig, ax = plt.subplots()
   plot_data = {}
-    
+
   # print concepts and classes with indentation
   for concept in result_summary:
-    if 'random' is not concept:
+    # TODO use random_concepts
+    if 'random500_' not in concept:
       print(2 * " ", "Concept =", concept)
 
       for bottleneck in result_summary[concept]:
@@ -246,9 +247,9 @@ def print_results_graph(results, min_p_val):
             "random was %.2f (+- %.2f). p-val = %.3f") % (
             bottleneck, np.mean(i_ups), np.std(i_ups),
             np.mean(random_i_ups[bottleneck]), np.std(random_i_ups[bottleneck]), p_val))
-      
-  # subtract 1 for random concept
-  num_concepts = len(result_summary) - 1
+
+  # subtract number of random experiments
+  num_concepts = len(result_summary) - num_random_exp
   num_bottlenecks = len(plot_data)
   bar_width = 0.35
     
@@ -256,6 +257,9 @@ def print_results_graph(results, min_p_val):
   # the final plot doesn't have any parts overlapping
   index = np.arange(num_concepts) * bar_width * (num_bottlenecks + 1)
 
+  # matplotlib
+  fig, ax = plt.subplots()
+    
   # draw all bottlenecks individually
   for i, [bn, vals] in enumerate(plot_data.items()):
     bar = ax.bar(index + i * bar_width, vals['bn_vals'], bar_width, yerr=vals['bn_stds'], label=bn)

--- a/utils.py
+++ b/utils.py
@@ -19,7 +19,6 @@ limitations under the License.
 import numpy as np
 import tensorflow as tf
 from scipy.stats import ttest_ind
-import matplotlib.pyplot as plt
 
 
 def create_session(timeout=10000, interactive=True):
@@ -48,7 +47,6 @@ def flatten(nested_list):
 
 
 def process_what_to_run_expand(pairs_to_test,
-                               random_counterpart,
                                num_random_exp=100,
                                random_concepts=None):
   """Get concept vs. random or random vs. random pairs to run.
@@ -62,7 +60,6 @@ def process_what_to_run_expand(pairs_to_test,
 
   Args:
     pairs_to_test: [(target, [concept1, concept2,...]),...]
-    random_counterpart: random concept that will be compared to the concept.
     num_random_exp: number of random experiments to run against each concept.
     random_concepts: A list of names of random concepts for the random
                      experiments to draw from. Optional, if not provided, the
@@ -84,8 +81,7 @@ def process_what_to_run_expand(pairs_to_test,
       i = 0
       while len(new_pairs_to_test_t) < min(100, num_random_exp):
         # make sure that we are not comparing the same thing to each other.
-        if concept_set[0] != get_random_concept(
-           i) and random_counterpart != get_random_concept(i):
+        if concept_set[0] != get_random_concept(i):
           new_pairs_to_test_t.append(
               (target, [concept_set[0], get_random_concept(i)]))
         i += 1
@@ -132,7 +128,7 @@ def process_what_to_run_randoms(pairs_to_test, random_counterpart):
   Args:
     pairs_to_test: a list of concepts to be tested and a target (e.g,
      [ ("target1",  ["concept1", "concept2", "concept3"]),...])
-    random_counterpart: random concept that will be compared to the concept.
+    random_counterpart: a random concept that will be compared to the concept.
 
   Returns:
     return pairs to test:
@@ -149,32 +145,8 @@ def process_what_to_run_randoms(pairs_to_test, random_counterpart):
 
 
 # helper functions to write summary files
-def print_results(results):
-  """Helper function to organize results.
-
-  Args:
-    results: dictionary of results from TCAV runs.
-  """
-  result_summary = {'random': []}
-  for result in results:
-    if 'random' in result['cav_concept']:
-      result_summary['random'].append(result)
-    else:
-      if result['cav_concept'] not in result_summary:
-        result_summary[result['cav_concept']] = []
-      result_summary[result['cav_concept']].append(result)
-  random_i_ups = [item['i_up'] for item in result_summary['random']]
-
-  for concept in result_summary:
-    if 'random' is not concept:
-      i_ups = [item['i_up'] for item in result_summary[concept]]
-      print('%s: TCAV score: %.2f (+- %.2f), random was %.2f' % (
-          concept, np.mean(i_ups), np.std(i_ups), np.mean(random_i_ups)))
-
-
-# function to output all results both in a printed format, and in a 
-# matplotlib graph when in interactive mode
-def print_results_graph(results, min_p_val, num_random_exp):
+# optionally output plot with matplotlib
+def print_results(results, num_random_exp=100, random_concepts=None, min_p_val=0.05, output_plot=False):
   """Helper function to organize results.
   When run in a notebook, outputs a matplotlib bar plot of the
   TCAV scores for all bottlenecks for each concept, replacing the
@@ -204,8 +176,9 @@ def print_results_graph(results, min_p_val, num_random_exp):
     result_summary[result['cav_concept']][result['bottleneck']].append(result)
     
     # store random
-    #TODO use random_concepts
-    if 'random500_' in result['cav_concept']:
+    # check if random concepts are from a supplied list first
+    if (random_concepts and result['cav_concept'] in random_concepts) \
+        or (not random_concepts and 'random500_' in result['cav_concept']):
       if result['bottleneck'] not in random_i_ups:
         random_i_ups[result['bottleneck']] = []
         
@@ -213,24 +186,23 @@ def print_results_graph(results, min_p_val, num_random_exp):
     
   # to plot, must massage data again 
   plot_data = {}
-
+    
   # print concepts and classes with indentation
   for concept in result_summary:
-    # TODO use random_concepts
-    if 'random500_' not in concept:
-      print(2 * " ", "Concept =", concept)
+        
+    # if not random
+    if (random_concepts and concept not in random_concepts) \
+        or (not random_concepts and 'random500_' not in concept):
+      print(" ", "Concept =", concept)
 
       for bottleneck in result_summary[concept]:
         i_ups = [item['i_up'] for item in result_summary[concept][bottleneck]]
         
         # Calculate statistical significance
-        t_val, p_val = ttest_ind(random_i_ups[bottleneck], i_ups)
+        _, p_val = ttest_ind(random_i_ups[bottleneck], i_ups)
                   
         if bottleneck not in plot_data:
-          plot_data[bottleneck] = {}
-          plot_data[bottleneck]['bn_vals'] = []
-          plot_data[bottleneck]['bn_stds'] = []
-          plot_data[bottleneck]['significant'] = []
+          plot_data[bottleneck] = {'bn_vals': [], 'bn_stds': [], 'significant': []}
 
         if p_val > min_p_val:
           # statistically insignificant
@@ -243,13 +215,24 @@ def print_results_graph(results, min_p_val, num_random_exp):
           plot_data[bottleneck]['bn_stds'].append(np.std(i_ups))
           plot_data[bottleneck]['significant'].append(True)
 
-        print(6 * " ", "Bottleneck =", ("%s. TCAV Score = %.2f (+- %.2f), "
+        print(3 * " ", "Bottleneck =", ("%s. TCAV Score = %.2f (+- %.2f), "
             "random was %.2f (+- %.2f). p-val = %.3f") % (
             bottleneck, np.mean(i_ups), np.std(i_ups),
-            np.mean(random_i_ups[bottleneck]), np.std(random_i_ups[bottleneck]), p_val))
+            np.mean(random_i_ups[bottleneck]),
+            np.std(random_i_ups[bottleneck]), p_val))
+        
+  # plot
+  if not output_plot:
+    return
 
+  import matplotlib.pyplot as plt
+        
   # subtract number of random experiments
-  num_concepts = len(result_summary) - num_random_exp
+  if random_concepts:
+    num_concepts = len(result_summary) - len(random_concepts)
+  else: 
+    num_concepts = len(result_summary) - num_random_exp
+    
   num_bottlenecks = len(plot_data)
   bar_width = 0.35
     
@@ -262,23 +245,26 @@ def print_results_graph(results, min_p_val, num_random_exp):
     
   # draw all bottlenecks individually
   for i, [bn, vals] in enumerate(plot_data.items()):
-    bar = ax.bar(index + i * bar_width, vals['bn_vals'], bar_width, yerr=vals['bn_stds'], label=bn)
+    bar = ax.bar(index + i * bar_width, vals['bn_vals'],
+        bar_width, yerr=vals['bn_stds'], label=bn)
     
     # draw stars to mark bars that are stastically insignificant to 
     # show them as different from others
     for j, significant in enumerate(vals['significant']):
       if not significant:
         ax.text(index[j] + i * bar_width - 0.1, 0.01, "*",
-            fontdict = {'weight': 'bold', 'size': 16, 'color': bar.patches[0].get_facecolor()})
+            fontdict = {'weight': 'bold', 'size': 16,
+            'color': bar.patches[0].get_facecolor()})
     
   # set properties
   ax.set_title('TCAV Scores for each concept and bottleneck')
   ax.set_ylabel('TCAV Score')
   ax.set_xticks(index + num_bottlenecks * bar_width / 2)
-  ax.set_xticklabels(tuple([concept for concept in result_summary if concept != 'random']))
+  ax.set_xticklabels(tuple(result_summary))
   ax.legend()
   fig.tight_layout()
   plt.show()
+
 
 def make_dir_if_not_exists(directory):
   if not tf.gfile.Exists(directory):

--- a/utils.py
+++ b/utils.py
@@ -154,6 +154,11 @@ def print_results(results, num_random_exp=100, random_concepts=None, min_p_val=0
 
   Args:
     results: dictionary of results from TCAV runs.
+    output_plot: True to output a plot using matplotlib, False to just
+                 output a text summary. If false, the following kwargs
+                 are not needed
+    num_random_exp: number of random experiments that were run
+    random_concepts: list of random experiments that were run
     min_p_val: minimum p value for statistical significance
   """
   # print class, it will be the same for all

--- a/utils.py
+++ b/utils.py
@@ -83,8 +83,8 @@ def process_what_to_run_expand(pairs_to_test,
       i = 0
       while len(new_pairs_to_test_t) < min(100, num_random_exp):
         # make sure that we are not comparing the same thing to each other.
-        if concept_set[0] != get_random_concept(i) \
-            and random_counterpart != get_random_concept(i):
+        if concept_set[0] != get_random_concept(
+            i) and random_counterpart != get_random_concept(i):
           new_pairs_to_test_t.append(
               (target, [concept_set[0], get_random_concept(i)]))
         i += 1

--- a/utils.py
+++ b/utils.py
@@ -18,6 +18,8 @@ limitations under the License.
 """
 import numpy as np
 import tensorflow as tf
+from scipy.stats import ttest_ind
+import matplotlib.pyplot as plt
 
 
 def create_session(timeout=10000, interactive=True):
@@ -169,6 +171,110 @@ def print_results(results):
       print('%s: TCAV score: %.2f (+- %.2f), random was %.2f' % (
           concept, np.mean(i_ups), np.std(i_ups), np.mean(random_i_ups)))
 
+
+# function to output all results both in a printed format, and in a 
+# matplotlib graph when in interactive mode
+def print_results_graph(results, min_p_val):
+  """Helper function to organize results.
+  When run in a notebook, outputs a matplotlib bar plot of the
+  TCAV scores for all bottlenecks for each concept, replacing the
+  bars with asterisks when the TCAV score is not statistically significant.
+
+  Args:
+    results: dictionary of results from TCAV runs.
+    min_p_val: minimum p value for statistical significance
+  """
+  # print class, it will be the same for all
+  print("Class =", results[0]['target_class'])
+
+  # prepare data
+  # dict with keys of concepts containing dict with bottlenecks
+  result_summary = {}
+    
+  # random
+  random_i_ups = {}
+    
+  for result in results:
+    if result['cav_concept'] not in result_summary:
+      result_summary[result['cav_concept']] = {}
+    
+    if result['bottleneck'] not in result_summary[result['cav_concept']]:
+      result_summary[result['cav_concept']][result['bottleneck']] = []
+    
+    result_summary[result['cav_concept']][result['bottleneck']].append(result)
+    
+    # store random
+    if result['cav_concept'] == 'random':
+      if result['bottleneck'] not in random_i_ups:
+        random_i_ups[result['bottleneck']] = []
+        
+      random_i_ups[result['bottleneck']].append(result['i_up'])
+    
+  # to plot, must massage data again 
+  fig, ax = plt.subplots()
+  plot_data = {}
+    
+  # print concepts and classes with indentation
+  for concept in result_summary:
+    if 'random' is not concept:
+      print(2 * " ", "Concept =", concept)
+
+      for bottleneck in result_summary[concept]:
+        i_ups = [item['i_up'] for item in result_summary[concept][bottleneck]]
+        
+        # Calculate statistical significance
+        t_val, p_val = ttest_ind(random_i_ups[bottleneck], i_ups)
+                  
+        if bottleneck not in plot_data:
+          plot_data[bottleneck] = {}
+          plot_data[bottleneck]['bn_vals'] = []
+          plot_data[bottleneck]['bn_stds'] = []
+          plot_data[bottleneck]['significant'] = []
+
+        if p_val > min_p_val:
+          # statistically insignificant
+          plot_data[bottleneck]['bn_vals'].append(0.01)
+          plot_data[bottleneck]['bn_stds'].append(0)
+          plot_data[bottleneck]['significant'].append(False)
+            
+        else:
+          plot_data[bottleneck]['bn_vals'].append(np.mean(i_ups))
+          plot_data[bottleneck]['bn_stds'].append(np.std(i_ups))
+          plot_data[bottleneck]['significant'].append(True)
+
+        print(6 * " ", "Bottleneck =", ("%s. TCAV Score = %.2f (+- %.2f), "
+            "random was %.2f (+- %.2f). p-val = %.3f") % (
+            bottleneck, np.mean(i_ups), np.std(i_ups),
+            np.mean(random_i_ups[bottleneck]), np.std(random_i_ups[bottleneck]), p_val))
+      
+  # subtract 1 for random concept
+  num_concepts = len(result_summary) - 1
+  num_bottlenecks = len(plot_data)
+  bar_width = 0.35
+    
+  # create location for each bar. scale by an appropriate factor to ensure 
+  # the final plot doesn't have any parts overlapping
+  index = np.arange(num_concepts) * bar_width * (num_bottlenecks + 1)
+
+  # draw all bottlenecks individually
+  for i, [bn, vals] in enumerate(plot_data.items()):
+    bar = ax.bar(index + i * bar_width, vals['bn_vals'], bar_width, yerr=vals['bn_stds'], label=bn)
+    
+    # draw stars to mark bars that are stastically insignificant to 
+    # show them as different from others
+    for j, significant in enumerate(vals['significant']):
+      if not significant:
+        ax.text(index[j] + i * bar_width - 0.1, 0.01, "*",
+            fontdict = {'weight': 'bold', 'size': 16, 'color': bar.patches[0].get_facecolor()})
+    
+  # set properties
+  ax.set_title('TCAV Scores for each concept and bottleneck')
+  ax.set_ylabel('TCAV Score')
+  ax.set_xticks(index + num_bottlenecks * bar_width / 2)
+  ax.set_xticklabels(tuple([concept for concept in result_summary if concept != 'random']))
+  ax.legend()
+  fig.tight_layout()
+  plt.show()
 
 def make_dir_if_not_exists(directory):
   if not tf.gfile.Exists(directory):

--- a/utils_plot.py
+++ b/utils_plot.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 """Contains function for plotting results when used in a jupyter notebook.
+Requires matplotlib.
 """
 import numpy as np
 from scipy.stats import ttest_ind

--- a/utils_plot.py
+++ b/utils_plot.py
@@ -1,0 +1,154 @@
+"""
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""Contains function for plotting results when used in a jupyter notebook.
+"""
+import numpy as np
+from scipy.stats import ttest_ind
+import matplotlib.pyplot as plt
+
+
+# helper function to output plot and write summary data
+def plot_results(results, random_counterpart=None, random_concepts=None, num_random_exp=100,
+    min_p_val=0.05):
+  """Helper function to organize results.
+  When run in a notebook, outputs a matplotlib bar plot of the
+  TCAV scores for all bottlenecks for each concept, replacing the
+  bars with asterisks when the TCAV score is not statistically significant.
+  If you ran TCAV with a random_counterpart, supply it here, otherwise supply random_concepts.
+  If you get unexpected output, make sure you are using the correct keywords.
+
+  Args:
+    results: dictionary of results from TCAV runs.
+    random_counterpart: name of the random_counterpart used, if it was used. 
+    random_concepts: list of random experiments that were run. 
+    num_random_exp: number of random experiments that were run.
+    min_p_val: minimum p value for statistical significance
+  """
+
+  # helper function, returns if this is a random concept
+  def is_random_concept(concept):
+    if random_counterpart:
+      return random_counterpart == concept
+    
+    elif random_concepts:
+      return concept in random_concepts
+
+    else:
+      return 'random500_' in concept
+
+  # print class, it will be the same for all
+  print("Class =", results[0]['target_class'])
+
+  # prepare data
+  # dict with keys of concepts containing dict with bottlenecks
+  result_summary = {}
+    
+  # random
+  random_i_ups = {}
+    
+  for result in results:
+    if result['cav_concept'] not in result_summary:
+      result_summary[result['cav_concept']] = {}
+    
+    if result['bottleneck'] not in result_summary[result['cav_concept']]:
+      result_summary[result['cav_concept']][result['bottleneck']] = []
+    
+    result_summary[result['cav_concept']][result['bottleneck']].append(result)
+
+    # store random
+    if is_random_concept(result['cav_concept']):
+      if result['bottleneck'] not in random_i_ups:
+        random_i_ups[result['bottleneck']] = []
+        
+      random_i_ups[result['bottleneck']].append(result['i_up'])
+    
+  # to plot, must massage data again 
+  plot_data = {}
+    
+  # print concepts and classes with indentation
+  for concept in result_summary:
+        
+    # if not random
+    if not is_random_concept(concept):
+      print(" ", "Concept =", concept)
+
+      for bottleneck in result_summary[concept]:
+        i_ups = [item['i_up'] for item in result_summary[concept][bottleneck]]
+        
+        # Calculate statistical significance
+        _, p_val = ttest_ind(random_i_ups[bottleneck], i_ups)
+                  
+        if bottleneck not in plot_data:
+          plot_data[bottleneck] = {'bn_vals': [], 'bn_stds': [], 'significant': []}
+
+        if p_val > min_p_val:
+          # statistically insignificant
+          plot_data[bottleneck]['bn_vals'].append(0.01)
+          plot_data[bottleneck]['bn_stds'].append(0)
+          plot_data[bottleneck]['significant'].append(False)
+            
+        else:
+          plot_data[bottleneck]['bn_vals'].append(np.mean(i_ups))
+          plot_data[bottleneck]['bn_stds'].append(np.std(i_ups))
+          plot_data[bottleneck]['significant'].append(True)
+
+        print(3 * " ", "Bottleneck =", ("%s. TCAV Score = %.2f (+- %.2f), "
+            "random was %.2f (+- %.2f). p-val = %.3f (%s)") % (
+            bottleneck, np.mean(i_ups), np.std(i_ups),
+            np.mean(random_i_ups[bottleneck]),
+            np.std(random_i_ups[bottleneck]), p_val,
+            "not significant" if p_val > min_p_val else "significant"))
+        
+  # subtract number of random experiments
+  if random_counterpart:
+    num_concepts = len(result_summary) - 1
+  elif random_concepts:
+    num_concepts = len(result_summary) - len(random_concepts)
+  else: 
+    num_concepts = len(result_summary) - num_random_exp
+    
+  num_bottlenecks = len(plot_data)
+  bar_width = 0.35
+    
+  # create location for each bar. scale by an appropriate factor to ensure 
+  # the final plot doesn't have any parts overlapping
+  index = np.arange(num_concepts) * bar_width * (num_bottlenecks + 1)
+
+  # matplotlib
+  fig, ax = plt.subplots()
+    
+  # draw all bottlenecks individually
+  for i, [bn, vals] in enumerate(plot_data.items()):
+    bar = ax.bar(index + i * bar_width, vals['bn_vals'],
+        bar_width, yerr=vals['bn_stds'], label=bn)
+    
+    # draw stars to mark bars that are stastically insignificant to 
+    # show them as different from others
+    for j, significant in enumerate(vals['significant']):
+      if not significant:
+        ax.text(index[j] + i * bar_width - 0.1, 0.01, "*",
+            fontdict = {'weight': 'bold', 'size': 16,
+            'color': bar.patches[0].get_facecolor()})
+    
+  # set properties
+  ax.set_title('TCAV Scores for each concept and bottleneck')
+  ax.set_ylabel('TCAV Score')
+  ax.set_xticks(index + num_bottlenecks * bar_width / 2)
+  ax.set_xticklabels(tuple(result_summary))
+  ax.legend()
+  fig.tight_layout()
+  plt.show()

--- a/utils_test.py
+++ b/utils_test.py
@@ -32,7 +32,6 @@ class UtilsTest(googletest.TestCase):
   def test_process_what_to_run_expand(self):
     all_concepts, pairs_to_test = process_what_to_run_expand(
         self.pair_to_test_one_concept,
-        self.random_counterpart,
         num_random_exp=2)
     self.assertEqual(
         sorted(all_concepts),
@@ -46,7 +45,6 @@ class UtilsTest(googletest.TestCase):
   def test_process_what_to_run_expand_specify_dirs(self):
     all_concepts, pairs_to_test = process_what_to_run_expand(
         self.pair_to_test_one_concept,
-        self.random_counterpart,
         num_random_exp=2,
         random_concepts=['random_dir1', 'random_dir2'])
     self.assertEqual(

--- a/utils_test.py
+++ b/utils_test.py
@@ -23,8 +23,7 @@ class UtilsTest(googletest.TestCase):
   def setUp(self):
     self.a_list = [[1, 2], [3, 4]]
     self.pairs_to_test = [('t1', ['c1', 'c2']), ('t2', ['c1', 'c2', 'c3'])]
-    self.pair_to_test_one_concept = [('t1', ['c1']), ('t1', ['random500_1'])]
-    self.random_counterpart = 'random500_1'
+    self.pair_to_test_one_concept = [('t1', ['c1']), ('t1', ['c2'])]
 
   def test_flatten(self):
     self.assertEqual([1, 2, 3, 4], flatten(self.a_list))
@@ -35,12 +34,12 @@ class UtilsTest(googletest.TestCase):
         num_random_exp=2)
     self.assertEqual(
         sorted(all_concepts),
-        sorted(['t1', 'c1', 'random500_2', 'random500_1', 'random500_0']))
+        sorted(['t1', 'c1', 'c2', 'random500_1', 'random500_0']))
     self.assertEqual(
         sorted(pairs_to_test),
-        sorted([('t1', ['c1', 'random500_0']), ('t1', ['c1', 'random500_2']),
-                ('t1', ['random500_1', 'random500_0']),
-                ('t1', ['random500_1', 'random500_2'])]))
+        sorted([('t1', ['c1', 'random500_0']), ('t1', ['c1', 'random500_1']),
+                ('t1', ['c2', 'random500_0']),
+                ('t1', ['c2', 'random500_1'])]))
 
   def test_process_what_to_run_expand_specify_dirs(self):
     all_concepts, pairs_to_test = process_what_to_run_expand(
@@ -49,12 +48,12 @@ class UtilsTest(googletest.TestCase):
         random_concepts=['random_dir1', 'random_dir2'])
     self.assertEqual(
         sorted(all_concepts),
-        sorted(['t1', 'c1', 'random500_1', 'random_dir1', 'random_dir2']))
+        sorted(['t1', 'c1', 'c2', 'random_dir1', 'random_dir2']))
     self.assertEqual(
         sorted(pairs_to_test),
         sorted([('t1', ['c1', 'random_dir1']), ('t1', ['c1', 'random_dir2']),
-                ('t1', ['random500_1', 'random_dir1']),
-                ('t1', ['random500_1', 'random_dir2'])]))
+                ('t1', ['c2', 'random_dir1']),
+                ('t1', ['c2', 'random_dir2'])]))
 
   def test_process_what_to_run_concepts(self):
     self.assertEqual(
@@ -70,7 +69,7 @@ class UtilsTest(googletest.TestCase):
     self.assertEqual(
         sorted(
             process_what_to_run_randoms(self.pairs_to_test,
-                                        self.random_counterpart)),
+                                        'random500_1')),
         sorted([['t1', ['random500_1']], ['t2', ['random500_1']]]))
 
 


### PR DESCRIPTION
Hello! As discussed previously, here is a pull request for some changes I've been working on. 

## Change list
- Files are now opened in binary mode for python3 compatibility
- Raise ValueError on trying to run TCAV on one image. Things seem to break when this happens. 
- Remove transparency channel from images
- Print results outputs summaries for multiple concepts, and optionally outputs a plot. See example below
- Changed the way random scores are calculated. Instead of nominating a single random_counterpart to use as the positive set, all negative sets of images are used in turn as the positve set. This has a great effect on the mean of the random concept, however is very computationally expensive. 
- Removed random_counterpart arg for TCAV
- Update tests for these changes

I understand you may not want random_concept removed, I can re-add it. What effect should it have? Also, maybe the change to random concepts should be optional due to the extra computation time required.

Another thing to look into here is to save computing time by noting that the TCAV score for random500_1 vs random500_0 should be the same as 1 - (random500_0 vs random500_1). I am currently unsure how to implement this however. 

Sample output from print_results can be seen below
![print_results](https://user-images.githubusercontent.com/7027531/53132826-c6fb6a00-35bc-11e9-9a1a-a198bd48068b.png)