### PR TITLE
activation_generator: use a default arg to normalize input images.

### DIFF
--- a/tcav/activation_generator.py
+++ b/tcav/activation_generator.py
@@ -92,8 +92,10 @@ class ActivationGeneratorBase(ActivationGeneratorInterface):
 class ImageActivationGenerator(ActivationGeneratorBase):
   """Activation generator for a basic image model"""
 
-  def __init__(self, model, source_dir, acts_dir, max_examples=10):
+  def __init__(self, model, source_dir, acts_dir, max_examples=10,
+               normalize_image=True):
     self.source_dir = source_dir
+    self.normalize_image = normalize_image
     super(ImageActivationGenerator, self).__init__(
         model, acts_dir, max_examples)
 
@@ -124,9 +126,10 @@ class ImageActivationGenerator(ActivationGeneratorBase):
     try:
       # ensure image has no transparency channel
       img = np.array(PIL.Image.open(tf.gfile.Open(filename, 'rb')).convert(
-          'RGB').resize(shape, PIL.Image.BILINEAR))
-      # Normalize pixel values to between 0 and 1.
-      img = np.float32(img) / 255.0
+          'RGB').resize(shape, PIL.Image.BILINEAR), dtype=np.float32)
+      if self.normalize_image:
+        # Normalize pixel values to between 0 and 1.
+        img = img / 255.0
       if not (len(img.shape) == 3 and img.shape[2] == 3):
         return None
       else:

--- a/tcav/activation_generator.py
+++ b/tcav/activation_generator.py
@@ -94,6 +94,12 @@ class ImageActivationGenerator(ActivationGeneratorBase):
 
   def __init__(self, model, source_dir, acts_dir, max_examples=10,
                normalize_image=True):
+    """Initialize ImageActivationGenerator class."
+
+    Args:
+      normalize_image: A boolean indicating whether image pixels
+      should be normalized to between 0 and 1.
+    """
     self.source_dir = source_dir
     self.normalize_image = normalize_image
     super(ImageActivationGenerator, self).__init__(


### PR DESCRIPTION
Current ImageActivationGenerator always normalizes input image pixels
to [0,1] by dividing the raw pixel values by 255. This works for
inception-based preprocessing, but models like ResNet expects original
pixel values (prior to normalization). This PR uses a keyword argument
to control normalization. The default is to enable normalization.