### PR TITLE
Add example argument to gradient calculation

### DIFF
--- a/tcav/cav.py
+++ b/tcav/cav.py
@@ -310,10 +310,12 @@ def get_or_train_cav(concepts,
     if not overwrite and tf.gfile.Exists(cav_path):
       tf.logging.info('CAV already exists: {}'.format(cav_path))
       cav_instance = CAV.load_cav(cav_path)
+      tf.logging.info('CAV accuracies: {}'.format(cav_instance.accuracies))
       return cav_instance
 
   tf.logging.info('Training CAV {} - {} alpha {}'.format(
       concepts, bottleneck, cav_hparams.alpha))
   cav_instance = CAV(concepts, bottleneck, cav_hparams, cav_path)
   cav_instance.train({c: acts[c] for c in concepts})
+  tf.logging.info('CAV accuracies: {}'.format(cav_instance.accuracies))
   return cav_instance

--- a/tcav/model.py
+++ b/tcav/model.py
@@ -54,13 +54,14 @@ class ModelWrapper(six.with_metaclass(ABCMeta, object)):
       self.bottlenecks_gradients[bn] = tf.gradients(
           self.loss, self.bottlenecks_tensors[bn])[0]
 
-  def get_gradient(self, acts, y, bottleneck_name):
+  def get_gradient(self, acts, y, bottleneck_name, example):
     """Return the gradient of the loss with respect to the bottleneck_name.
 
     Args:
       acts: activation of the bottleneck
       y: index of the logit layer
       bottleneck_name: name of the bottleneck to get gradient wrt.
+      example: input example. Unused by default.
 
     Returns:
       the gradient array.

--- a/tcav/model.py
+++ b/tcav/model.py
@@ -61,7 +61,8 @@ class ModelWrapper(six.with_metaclass(ABCMeta, object)):
       acts: activation of the bottleneck
       y: index of the logit layer
       bottleneck_name: name of the bottleneck to get gradient wrt.
-      example: input example. Unused by default.
+      example: input example. Unused by default. Necessary for getting gradients
+        from certain models, such as BERT.
 
     Returns:
       the gradient array.

--- a/tcav/tcav_test.py
+++ b/tcav/tcav_test.py
@@ -29,7 +29,7 @@ class TcavTest_model():
   def __init__(self):
     self.model_name = 'test_model'
 
-  def get_gradient(self, act, class_id, bottleneck):
+  def get_gradient(self, act, class_id, bottleneck, example):
     return act
 
   def label_to_id(self, target_class):
@@ -57,6 +57,7 @@ class TcavTest(googletest.TestCase):
 
   def setUp(self):
     self.acts = np.array([[0, 1., 2.]])
+    self.examples = [None, None, None]
     self.concepts = ['c1', 'c2']
     self.target = 't1'
     self.class_id = 0
@@ -92,7 +93,8 @@ class TcavTest(googletest.TestCase):
                                                  self.acts,
                                                  self.cav,
                                                  self.concepts[0],
-                                                 self.class_id))
+                                                 self.class_id,
+                                                 None))
 
 
   def test_compute_tcav_score(self):
@@ -101,6 +103,7 @@ class TcavTest(googletest.TestCase):
                                     self.concepts[0],
                                     self.cav,
                                     self.acts,
+                                    self.examples,
                                     run_parallel=False)
     self.assertAlmostEqual(0., score)
 
@@ -109,7 +112,8 @@ class TcavTest(googletest.TestCase):
                                                 self.target,
                                                 self.concepts[0],
                                                 self.cav,
-                                                self.acts)
+                                                self.acts,
+                                                self.examples)
     self.assertAlmostEqual(8., directional_dirs[0])
 
   def test__run_single_set(self):


### PR DESCRIPTION
Some models, such as BERT, need access to the original example to get gradients, so adding this backwards-compatible change to support those models. With this change we can use TCAV on BERT for example.