### PR TITLE
Make acts dir when it does not exist

### DIFF
--- a/tcav/activation_generator.py
+++ b/tcav/activation_generator.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 from abc import ABCMeta
 from abc import abstractmethod
 from multiprocessing import dummy as multiprocessing
+import os
 import os.path
 import numpy as np
 import PIL.Image
@@ -84,6 +85,7 @@ class ActivationGeneratorBase(ActivationGeneratorInterface):
           if acts_path:
             tf.logging.info('{} does not exist, Making one...'.format(
                 acts_path))
+            tf.gfile.MkDir(os.path.dirname(acts_path))
             with tf.gfile.Open(acts_path, 'w') as f:
               np.save(f, acts[concept][bottleneck_name], allow_pickle=False)
     return acts


### PR DESCRIPTION
The current logging message implies that an acts directory should be created if it does not yet exist in process_and_load_activations(). 