### PR TITLE
Bugfix: update target_class from string to int

### DIFF
--- a/tcav/tcav_results/results.proto
+++ b/tcav/tcav_results/results.proto
@@ -20,7 +20,7 @@ message Result {
   optional string negative_concept = 3;
 
   // target class of the output layer
-  optional string target_class = 4;
+  optional int32 target_class = 4;
 
   optional CAVaccuracies cav_accuracies = 5;
 

--- a/tcav/utils_test.py
+++ b/tcav/utils_test.py
@@ -78,7 +78,7 @@ class UtilsTest(googletest.TestCase):
         'cav_key': 'c1-c2-b-model-0.1',
         'cav_concept': 'c1',
         'negative_concept': 'c2',
-        'target_class': 't',
+        'target_class': 0,
         'cav_accuracies': {'c1': .526, 'c2': .414, 'overall': .47},
         'i_up': 0.342,
         'val_directional_dirs_abs_mean': 0.25,
@@ -94,7 +94,7 @@ class UtilsTest(googletest.TestCase):
     result_proto.cav_key = 'c1-c2-b-model-0.1'
     result_proto.cav_concept = 'c1'
     result_proto.negative_concept = 'c2'
-    result_proto.target_class = 't'
+    result_proto.target_class = 0
     result_proto.i_up = 0.342
     result_proto.val_directional_dirs_abs_mean = 0.25
     result_proto.val_directional_dirs_mean = 0.25


### PR DESCRIPTION
The TCAV class treats target_class as an int. However, the Results proto defines target_class as a string. This causes TCAV to fail when attempting to return as a proto object instead of the dictionary default.