### PR TITLE
Add support for Relative TCAV

### DIFF
--- a/tcav/tcav.py
+++ b/tcav/tcav.py
@@ -151,7 +151,7 @@ class TCAV(object):
     Args:
       sess: tensorflow session.
       target: one target class
-      concepts: one concept
+      concepts: A list of names of positive concept sets.
       bottlenecks: the name of a bottleneck of interest.
       activation_generator: an ActivationGeneratorInterface instance to return
                             activations.
@@ -164,6 +164,8 @@ class TCAV(object):
       random_concepts: A list of names of random concepts for the random
                        experiments to draw from. Optional, if not provided, the
                        names will be random500_{i} for i in num_random_exp.
+                       Relative TCAV can be performed by passing in the same
+                       value for both concepts and random_concepts.
     """
     self.target = target
     self.concepts = concepts
@@ -175,6 +177,7 @@ class TCAV(object):
     self.model_to_run = self.mymodel.model_name
     self.sess = sess
     self.random_counterpart = random_counterpart
+    self.relative_tcav = (random_concepts is not None) and (set(concepts) == set(random_concepts))
 
     if random_concepts:
       num_random_exp = len(random_concepts)
@@ -321,12 +324,14 @@ class TCAV(object):
     target_concept_pairs = [(self.target, self.concepts)]
 
     # take away 1 random experiment if the random counterpart already in random concepts
+    # take away 1 random experiment if computing Relative TCAV
     all_concepts_concepts, pairs_to_run_concepts = (
         utils.process_what_to_run_expand(
             utils.process_what_to_run_concepts(target_concept_pairs),
             self.random_counterpart,
-            num_random_exp=num_random_exp - (1 if random_concepts and
-                  self.random_counterpart in random_concepts else 0),
+            num_random_exp=num_random_exp -
+            (1 if random_concepts and self.random_counterpart in random_concepts
+             else 0) - (1 if self.relative_tcav else 0),
             random_concepts=random_concepts))
 
     pairs_to_run_randoms = []
@@ -365,7 +370,7 @@ class TCAV(object):
       all_concepts_randoms.extend(all_concepts_randoms_tmp)
 
     self.all_concepts = list(set(all_concepts_concepts + all_concepts_randoms))
-    self.pairs_to_test = pairs_to_run_concepts + pairs_to_run_randoms
+    self.pairs_to_test = pairs_to_run_concepts if self.relative_tcav else pairs_to_run_concepts + pairs_to_run_randoms
 
   def get_params(self):
     """Enumerate parameters for the run function.

--- a/tcav/tcav_test.py
+++ b/tcav/tcav_test.py
@@ -209,6 +209,29 @@ class TcavTest(googletest.TestCase):
                             ('t1',['random500_1', 'random_dir2'])
                            ]))
 
+  def test__process_what_to_run_expand_relative_tcav(self):
+    # _process_what_to_run_expand stores results to all_concepts,
+    # and pairs_to_test.
+    # test when concepts and random_concepts contain the same elements
+    concepts_relative = ['c1', 'c2', 'c3']
+    my_relative_tcav = TCAV(None,
+                            self.target,
+                            concepts_relative,
+                            [self.bottleneck],
+                            self.act_gen,
+                            [self.hparams.alpha],
+                            random_concepts=concepts_relative)
+    self.assertEqual(sorted(my_relative_tcav.all_concepts),
+                     sorted(['t1', 'c1', 'c2', 'c3']))
+    self.assertEqual(sorted(my_relative_tcav.pairs_to_test),
+                     sorted([('t1',['c1', 'c2']),
+                             ('t1',['c1', 'c3']),
+                             ('t1',['c2', 'c1']),
+                             ('t1',['c2', 'c3']),
+                             ('t1',['c3', 'c1']),
+                             ('t1',['c3', 'c2']),
+                             ]))
+
   def test_get_params(self):
     """Check if the first param was correct.
     """


### PR DESCRIPTION
Relative TCAV is triggered by passing in the same list is passed in
for both the positive concept sets (`concepts`) and the negative
concept sets (`random_concepts`).

If this occurs, a random experiment must be removed (because there
will be overlap between the positive concept sets and negative concept sets).