### PR TITLE
Create session, load graph, and save tensors in ModelWrapper.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ scikit-learn=0.20.3
 scipy=1.2.1
 tensorflow=1.13.1
 numpy=1.13.3
+protobuf=3.10.0

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,6 @@ setup(name='tcav',
           'matplotlib>=2.2.4',
           'Pillow>=6.0.0',
           'scikit-learn>=0.20.3',
-          'scipy>=1.2.1'
+          'scipy>=1.2.1',
+          'protobuf>=3.10.0',
       ])

--- a/tcav/model.py
+++ b/tcav/model.py
@@ -194,15 +194,22 @@ class ModelWrapper(six.with_metaclass(ABCMeta, object)):
     """
     return np.asarray(layer_acts).squeeze()
 
-  @abstractmethod
   def label_to_id(self, label):
-    """Convert label (string) to index in the logit layer (id)."""
-    pass
+    """Convert label (string) to index in the logit layer (id).
 
-  @abstractmethod
+    Override this method if label to id mapping is known. Otherwise,
+    default id 0 is used.
+    """
+    tf.logging.warn('label_to_id undefined. Defaults to returning 0.')
+    return 0
+
+
   def id_to_label(self, idx):
-    """Convert index in the logit layer (id) to label (string)."""
-    pass
+    """Convert index in the logit layer (id) to label (string).
+
+    Override this method if id to label mapping is known.
+    """
+    return str(idx)
 
   def run_examples(self, examples, bottleneck_name):
     """Get activations at a bottleneck for provided examples.

--- a/tcav/model.py
+++ b/tcav/model.py
@@ -44,7 +44,10 @@ class ModelWrapper(six.with_metaclass(ABCMeta, object)):
         Directory path to SavedModel 3) File path to frozen graph.pb 4) File
         path to frozen graph.pbtxt
       node_dict: mapping from a short name to full input/output and bottleneck
-        tensor names.
+        tensor names. Users should pass 'input' and 'prediction'
+        as keys and the corresponding input and prediction tensor
+        names as values in node_dict. Users can additionally pass bottleneck
+        tensor names for which gradient Ops will be added later.
     """
     # A dictionary of bottleneck tensors.
     self.bottlenecks_tensors = None
@@ -114,6 +117,7 @@ class ModelWrapper(six.with_metaclass(ABCMeta, object)):
 
     Depending on how the model is loaded, tensors in the graph
     may or may not have 'import/' prefix added to every tensor name.
+    This is true even if the tensors already have 'import/' prefix.
     The 'ends' and 'bottlenecks_tensors' dictionary should map to tensors
     with the according name.
     """

--- a/tcav/model.py
+++ b/tcav/model.py
@@ -23,6 +23,7 @@ from six.moves import zip
 import numpy as np
 import six
 import tensorflow as tf
+from google.protobuf import text_format
 
 class ModelWrapper(six.with_metaclass(ABCMeta, object)):
   """Simple wrapper of the for models with session object for TCAV.
@@ -31,7 +32,20 @@ class ModelWrapper(six.with_metaclass(ABCMeta, object)):
   """
 
   @abstractmethod
-  def __init__(self):
+  def __init__(self, model_path=None, node_dict=None):
+    """Initialize the wrapper.
+
+    Optionally create a session, load
+    the model from model_path to this session, and map the
+    input/output and bottleneck tensors.
+
+    Args:
+      model_path: one of the following: 1) Directory path to checkpoint 2)
+        Directory path to SavedModel 3) File path to frozen graph.pb 4) File
+        path to frozen graph.pbtxt
+      node_dict: mapping from a short name to full input/output and bottleneck
+        tensor names.
+    """
     # A dictionary of bottleneck tensors.
     self.bottlenecks_tensors = None
     # A dictionary of input, 'logit' and prediction tensors.
@@ -45,6 +59,74 @@ class ModelWrapper(six.with_metaclass(ABCMeta, object)):
     self.y_input = None
     # The tensor representing the loss (used to calculate derivative).
     self.loss = None
+    # If tensors in the loaded graph are prefixed with 'import/'
+    self.import_prefix = False
+
+    if model_path:
+      self._try_loading_model(model_path)
+    if node_dict:
+      self._find_ends_and_bottleneck_tensors(node_dict)
+
+  def _try_loading_model(self, model_path):
+    """ Load model from model_path.
+
+    TF models are often saved in one of the three major formats:
+      1) Checkpoints with ckpt.meta, ckpt.data, and ckpt.index.
+      2) SavedModel format with saved_model.pb and variables/.
+      3) Frozen graph in .pb or .pbtxt format.
+    When model_path is specified, model is loaded in one of the
+    three formats depending on the model_path. When model_path is
+    ommitted, child wrapper is responsible for loading the model.
+    """
+    try:
+      self.sess = tf.Session(graph=tf.Graph())
+      with self.sess.graph.as_default():
+        if tf.gfile.IsDirectory(model_path):
+          ckpt = tf.train.latest_checkpoint(model_path)
+          if ckpt:
+            tf.logging.info('Loading from the latest checkpoint.')
+            saver = tf.train.import_meta_graph(ckpt + '.meta')
+            saver.restore(self.sess, ckpt)
+          else:
+            tf.logging.info('Loading from SavedModel dir.')
+            tf.saved_model.loader.load(self.sess, ['serve'], model_path)
+        else:
+          input_graph_def = tf.GraphDef()
+          if model_path.endswith('.pb'):
+            tf.logging.info('Loading from frozen binary graph.')
+            with tf.gfile.FastGFile(model_path, 'rb') as f:
+              input_graph_def.ParseFromString(f.read())
+          else:
+            tf.logging.info('Loading from frozen text graph.')
+            with tf.gfile.FastGFile(model_path) as f:
+              text_format.Parse(f.read(), input_graph_def)
+          tf.import_graph_def(input_graph_def)
+          self.import_prefix = True
+
+    except Exception as e:
+      template = 'An exception of type {0} occurred ' \
+                 'when trying to load model from {1}. ' \
+                 'Arguments:\n{2!r}'
+      tf.logging.warn(template.format(type(e).__name__, model_path, e.args))
+
+  def _find_ends_and_bottleneck_tensors(self, node_dict):
+    """ Find tensors from the graph by their names.
+
+    Depending on how the model is loaded, tensors in the graph
+    may or may not have 'import/' prefix added to every tensor name.
+    The 'ends' and 'bottlenecks_tensors' dictionary should map to tensors
+    with the according name.
+    """
+    self.bottlenecks_tensors = {}
+    self.ends = {}
+    for k, v in node_dict.iteritems():
+      if self.import_prefix:
+        v = 'import/' + v
+      tensor = self.sess.graph.get_operation_by_name(v.strip(':0')).outputs[0]
+      if k == 'input' or k == 'prediction':
+        self.ends[k] = tensor
+      else:
+        self.bottlenecks_tensors[k] = tensor
 
   def _make_gradient_tensors(self):
     """Makes gradient tensors for all bottleneck tensors.

--- a/tcav/model_test.py
+++ b/tcav/model_test.py
@@ -27,12 +27,6 @@ class ModelTest_model(ModelWrapper):
     super(ModelTest_model, self).__init__(
         model_path=model_path, node_dict=node_dict)
 
-  def label_to_id(self, target_class):
-    return 0
-
-  def id_to_label(self, idx):
-    return 0
-
 
 class ModelTest(googletest.TestCase):
 

--- a/tcav/model_test.py
+++ b/tcav/model_test.py
@@ -1,0 +1,120 @@
+"""
+Copyright 2019 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+import tensorflow as tf
+from tensorflow.python.framework import graph_util
+from tensorflow.python.platform import googletest
+from tcav.model import ModelWrapper
+
+
+class ModelTest_model(ModelWrapper):
+  """A mock model of model class for ModelTest class."""
+
+  def __init__(self, model_path=None, node_dict=None):
+    super(ModelTest_model, self).__init__(
+        model_path=model_path, node_dict=node_dict)
+
+  def label_to_id(self, target_class):
+    return 0
+
+  def id_to_label(self, idx):
+    return 0
+
+
+class ModelTest(googletest.TestCase):
+
+  def setUp(self):
+    # Create an execution graph
+    x = tf.placeholder(dtype=tf.float64, shape=[], name='input')
+    a = tf.Variable(111, name='var1', dtype=tf.float64)
+    y = tf.math.multiply(x, a, name='output')
+
+    self.ckpt_dir = '/tmp/ckpts/'
+    self.saved_model_dir = '/tmp/saved_model/'
+    self.frozen_graph_dir = '/tmp/frozen_graph/'
+    self.tmp_dirs = [self.ckpt_dir, self.saved_model_dir, self.frozen_graph_dir]
+    for d in self.tmp_dirs:
+      if tf.gfile.Exists(d):
+        tf.gfile.DeleteRecursively(d)
+        tf.gfile.MakeDirs(d)
+
+    with tf.Session() as sess:
+      tf.initialize_all_variables().run()
+
+      # Save as checkpoint
+      saver = tf.train.Saver()
+      saver.save(sess, self.ckpt_dir + 'model.ckpt', write_meta_graph=True)
+
+      # Save as SavedModel
+      tf.saved_model.simple_save(
+          sess,
+          self.saved_model_dir,
+          inputs={'input': x},
+          outputs={'output': y})
+
+      graph = sess.graph
+      input_graph_def = graph.as_graph_def()
+      output_node_names = ['output']
+      output_graph_def = graph_util.convert_variables_to_constants(
+          sess, input_graph_def, output_node_names)
+
+      # Save as binary graph
+      tf.io.write_graph(
+          output_graph_def, self.frozen_graph_dir, 'graph.pb', as_text=False)
+
+      # Save as text graph
+      tf.io.write_graph(
+          output_graph_def, self.frozen_graph_dir, 'graph.pbtxt', as_text=True)
+
+  def tearDown(self):
+    for d in self.tmp_dirs:
+      tf.gfile.DeleteRecursively(d)
+
+  def _check_output_and_gradient(self, model_path, import_prefix=False):
+    model = ModelTest_model(model_path=model_path, node_dict={'v1': 'var1'})
+    input_name = 'input:0'
+    output_name = 'output:0'
+    if import_prefix:
+      input_name = 'import/' + input_name
+      output_name = 'import/' + output_name
+    out = model.sess.run(output_name, feed_dict={input_name: 3})
+    self.assertEqual(out, 333.0)
+
+    model.loss = model.sess.graph.get_tensor_by_name(output_name)
+
+    # Make sure that loaded graph can be modified
+    model._make_gradient_tensors()
+    grad = model.sess.run(
+        model.bottlenecks_gradients['v1'], feed_dict={input_name: 555})
+    self.assertEqual(grad, 555.0)
+
+  def test_try_loading_model_from_ckpt(self):
+    self._check_output_and_gradient(self.ckpt_dir)
+
+  def test_try_loading_model_from_saved_model(self):
+    self._check_output_and_gradient(self.saved_model_dir)
+
+  def test_try_loading_model_from_frozen_pb(self):
+    model_path = self.frozen_graph_dir + 'graph.pb'
+    self._check_output_and_gradient(model_path, import_prefix=True)
+
+  def test_try_loading_model_from_frozen_txt(self):
+    model_path = self.frozen_graph_dir + 'graph.pbtxt'
+    self._check_output_and_gradient(model_path, import_prefix=True)
+
+
+if __name__ == '__main__':
+  googletest.main()


### PR DESCRIPTION
When model_path is specified, a session is created for the base
ModelWrapper. The graph is loaded from model_path by trying
a few different graph format. Tensors specified in node_dict
are saved to the corresponding ends and bottleneck_tensors dict.