### PR TITLE
Get UTs to work out-of-the-box

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ matplotlib==2.2.4
 Pillow==6.2.0
 scikit-learn==0.20.3
 scipy==1.2.1
-tensorflow==1.15.2
-numpy==1.13.3
+tensorflow==1.15.0
+numpy==1.16.0
 protobuf==3.10.0

--- a/tcav/activation_generator.py
+++ b/tcav/activation_generator.py
@@ -65,8 +65,8 @@ class ActivationGeneratorBase(ActivationGeneratorInterface):
 
   def process_and_load_activations(self, bottleneck_names, concepts):
     acts = {}
-    if self.acts_dir and not tf.gfile.Exists(self.acts_dir):
-      tf.gfile.MakeDirs(self.acts_dir)
+    if self.acts_dir and not tf.io.gfile.exists(self.acts_dir):
+      tf.io.gfile.makedirs(self.acts_dir)
 
     for concept in concepts:
       if concept not in acts:
@@ -74,8 +74,8 @@ class ActivationGeneratorBase(ActivationGeneratorInterface):
       for bottleneck_name in bottleneck_names:
         acts_path = os.path.join(self.acts_dir, 'acts_{}_{}'.format(
             concept, bottleneck_name)) if self.acts_dir else None
-        if acts_path and tf.gfile.Exists(acts_path):
-          with tf.gfile.Open(acts_path, 'rb') as f:
+        if acts_path and tf.io.gfile.exists(acts_path):
+          with tf.io.gfile.GFile(acts_path, 'rb') as f:
             acts[concept][bottleneck_name] = np.load(
                 f, allow_pickle=True).squeeze()
             tf.logging.info('Loaded {} shape {}'.format(
@@ -86,8 +86,8 @@ class ActivationGeneratorBase(ActivationGeneratorInterface):
           if acts_path:
             tf.logging.info('{} does not exist, Making one...'.format(
                 acts_path))
-            tf.gfile.MkDir(os.path.dirname(acts_path))
-            with tf.gfile.Open(acts_path, 'w') as f:
+            tf.io.gfile.mkdir(os.path.dirname(acts_path))
+            with tf.io.gfile.GFile(acts_path, 'w') as f:
               np.save(f, acts[concept][bottleneck_name], allow_pickle=False)
     return acts
 
@@ -111,7 +111,7 @@ class ImageActivationGenerator(ActivationGeneratorBase):
   def get_examples_for_concept(self, concept):
     concept_dir = os.path.join(self.source_dir, concept)
     img_paths = [os.path.join(concept_dir, d)
-                 for d in tf.gfile.ListDirectory(concept_dir)]
+                 for d in tf.io.gfile.listdir(concept_dir)]
     imgs = self.load_images_from_files(img_paths, self.max_examples,
                                        shape=self.model.get_image_shape()[:2])
     return imgs
@@ -129,12 +129,12 @@ class ImageActivationGenerator(ActivationGeneratorBase):
     Rasies:
       exception if the image was not the right shape.
     """
-    if not tf.gfile.Exists(filename):
+    if not tf.io.gfile.exists(filename):
       tf.logging.error('Cannot find file: {}'.format(filename))
       return None
     try:
       # ensure image has no transparency channel
-      img = np.array(PIL.Image.open(tf.gfile.Open(filename, 'rb')).convert(
+      img = np.array(PIL.Image.open(tf.io.gfile.GFile(filename, 'rb')).convert(
           'RGB').resize(shape, PIL.Image.BILINEAR), dtype=np.float32)
       if self.normalize_image:
         # Normalize pixel values to between 0 and 1.

--- a/tcav/cav.py
+++ b/tcav/cav.py
@@ -57,7 +57,7 @@ class CAV(object):
     Returns:
       CAV instance.
     """
-    with tf.gfile.Open(cav_path, 'rb') as pkl_file:
+    with tf.io.gfile.GFile(cav_path, 'rb') as pkl_file:
       save_dict = pickle.load(pkl_file)
 
     cav = CAV(save_dict['concepts'], save_dict['bottleneck'],
@@ -99,7 +99,7 @@ class CAV(object):
         cav_dir,
         CAV.cav_key(concepts, bottleneck, cav_hparams.model_type,
                     cav_hparams.alpha) + '.pkl')
-    return tf.gfile.Exists(cav_path)
+    return tf.io.gfile.exists(cav_path)
 
   @staticmethod
   def _create_cav_training_set(concepts, bottleneck, acts):
@@ -226,7 +226,7 @@ class CAV(object):
         'saved_path': self.save_path
     }
     if self.save_path is not None:
-      with tf.gfile.Open(self.save_path, 'w') as pkl_file:
+      with tf.io.gfile.GFile(self.save_path, 'w') as pkl_file:
         pickle.dump(save_dict, pkl_file)
     else:
       tf.logging.info('save_path is None. Not saving anything')
@@ -307,7 +307,7 @@ def get_or_train_cav(concepts,
         CAV.cav_key(concepts, bottleneck, cav_hparams.model_type,
                     cav_hparams.alpha).replace('/', '.') + '.pkl')
 
-    if not overwrite and tf.gfile.Exists(cav_path):
+    if not overwrite and tf.io.gfile.exists(cav_path):
       tf.logging.info('CAV already exists: {}'.format(cav_path))
       cav_instance = CAV.load_cav(cav_path)
       tf.logging.info('CAV accuracies: {}'.format(cav_instance.accuracies))

--- a/tcav/cav_test.py
+++ b/tcav/cav_test.py
@@ -26,7 +26,7 @@ from tensorflow.python.platform import flags
 from tensorflow.python.platform import googletest
 
 FLAGS = flags.FLAGS
-flags.DEFINE_string(name='test_tmpdir', default='/tmp',
+flags.DEFINE_string(name='tcav_test_tmpdir', default='/tmp',
                     help='Temporary directory for test files')
 
 class CavTest(googletest.TestCase):
@@ -36,13 +36,14 @@ class CavTest(googletest.TestCase):
 
     The cav instance uses preset values.
     """
-    self.hparams = tf.contrib.training.HParams(model_type='linear', alpha=.01)
+    self.hparams = tf.contrib.training.HParams(
+      model_type='linear', alpha=.01, max_iter=1000, tol=1e-3)
     self.concepts = ['concept1', 'concept2']
     self.bottleneck = 'bottleneck'
     self.accuracies = {'concept1': 0.8, 'concept2': 0.5, 'overall': 0.65}
     self.cav_vecs = [[1, 2, 3], [4, 5, 6]]
 
-    self.test_subdirectory = os.path.join(FLAGS.test_tmpdir, 'test')
+    self.test_subdirectory = os.path.join(FLAGS.tcav_test_tmpdir, 'test')
     self.cav_dir = self.test_subdirectory
     self.cav_file_name = CAV.cav_key(self.concepts, self.bottleneck,
                                          self.hparams.model_type,
@@ -61,7 +62,7 @@ class CavTest(googletest.TestCase):
     if os.path.exists(self.cav_dir):
       shutil.rmtree(self.cav_dir)
     os.mkdir(self.cav_dir)
-    with tf.gfile.Open(self.save_path, 'w') as pkl_file:
+    with tf.io.gfile.GFile(self.save_path, 'w') as pkl_file:
       pickle.dump({
           'concepts': self.concepts,
           'bottleneck': self.bottleneck,

--- a/tcav/model.py
+++ b/tcav/model.py
@@ -315,7 +315,7 @@ class PublicImageModelWrapper(ImageModelWrapper):
         'Scope "%s" already exists. Provide explicit scope names when '
         'importing multiple instances of the model.') % scope
 
-    graph_def = tf.GraphDef.FromString(tf.io.gfile.GFilen(saved_path, 'rb').read())
+    graph_def = tf.GraphDef.FromString(tf.io.gfile.GFile(saved_path, 'rb').read())
 
     with tf.name_scope(scope) as sc:
       t_input, t_prep_input = PublicImageModelWrapper.create_input(

--- a/tcav/model.py
+++ b/tcav/model.py
@@ -84,7 +84,7 @@ class ModelWrapper(six.with_metaclass(ABCMeta, object)):
     try:
       self.sess = tf.Session(graph=tf.Graph())
       with self.sess.graph.as_default():
-        if tf.gfile.IsDirectory(model_path):
+        if tf.io.gfile.isdir(model_path):
           ckpt = tf.train.latest_checkpoint(model_path)
           if ckpt:
             tf.logging.info('Loading from the latest checkpoint.')
@@ -97,11 +97,11 @@ class ModelWrapper(six.with_metaclass(ABCMeta, object)):
           input_graph_def = tf.GraphDef()
           if model_path.endswith('.pb'):
             tf.logging.info('Loading from frozen binary graph.')
-            with tf.gfile.FastGFile(model_path, 'rb') as f:
+            with tf.io.gfile.GFile(model_path, 'rb') as f:
               input_graph_def.ParseFromString(f.read())
           else:
             tf.logging.info('Loading from frozen text graph.')
-            with tf.gfile.FastGFile(model_path) as f:
+            with tf.io.gfile.GFile(model_path) as f:
               text_format.Parse(f.read(), input_graph_def)
           tf.import_graph_def(input_graph_def)
           self.import_prefix = True
@@ -249,7 +249,7 @@ class PublicImageModelWrapper(ImageModelWrapper):
                endpoints_dict,
                scope):
     super(PublicImageModelWrapper, self).__init__(image_shape)
-    self.labels = tf.gfile.Open(labels_path).read().splitlines()
+    self.labels = tf.io.gfile.GFile(labels_path).read().splitlines()
     self.ends = PublicImageModelWrapper.import_graph(model_fn_path,
                                                      endpoints_dict,
                                                      self.image_value_range,
@@ -315,7 +315,7 @@ class PublicImageModelWrapper(ImageModelWrapper):
         'Scope "%s" already exists. Provide explicit scope names when '
         'importing multiple instances of the model.') % scope
 
-    graph_def = tf.GraphDef.FromString(tf.gfile.Open(saved_path, 'rb').read())
+    graph_def = tf.GraphDef.FromString(tf.io.gfile.GFilen(saved_path, 'rb').read())
 
     with tf.name_scope(scope) as sc:
       t_input, t_prep_input = PublicImageModelWrapper.create_input(

--- a/tcav/tcav.py
+++ b/tcav/tcav.py
@@ -209,12 +209,12 @@ class TCAV(object):
     now = time.time()
     if run_parallel:
       pool = multiprocessing.Pool(num_workers)
-      results = pool.map(lambda param: self._run_single_set(param, overwrite=overwrite), self.params)
+      results = pool.map(lambda param: self._run_single_set(param, overwrite=overwrite, run_parallel=run_parallel), self.params)
     else:
       results = []
       for i, param in enumerate(self.params):
         tf.logging.info('Running param %s of %s' % (i, len(self.params)))
-        results.append(self._run_single_set(param, overwrite=overwrite))
+        results.append(self._run_single_set(param, overwrite=overwrite, run_parallel=run_parallel))
     tf.logging.info('Done running %s params. Took %s seconds...' % (len(
         self.params), time.time() - now))
     if return_proto:
@@ -222,12 +222,13 @@ class TCAV(object):
     else:
       return results
 
-  def _run_single_set(self, param, overwrite=False):
+  def _run_single_set(self, param, overwrite=False, run_parallel=False):
     """Run TCAV with provided for one set of (target, concepts).
 
     Args:
       param: parameters to run
       overwrite: if True, overwrite any saved CAV files.
+      run_parallel: run this parallel.
 
     Returns:
       a dictionary of results (panda frame)
@@ -271,7 +272,8 @@ class TCAV(object):
     i_up = self.compute_tcav_score(
         mymodel, target_class_for_compute_tcav_score, cav_concept,
         cav_instance, acts[target_class][cav_instance.bottleneck],
-        activation_generator.get_examples_for_concept(target_class))
+        activation_generator.get_examples_for_concept(target_class),
+        run_parallel=run_parallel)
     val_directional_dirs = self.get_directional_dir(
         mymodel, target_class_for_compute_tcav_score, cav_concept,
         cav_instance, acts[target_class][cav_instance.bottleneck],

--- a/tcav/tcav_results/results_pb2.py
+++ b/tcav/tcav_results/results_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='tcav_results',
   syntax='proto2',
   serialized_options=None,
-  serialized_pb=_b('\n\x1atcav_results/results.proto\x12\x0ctcav_results\"\xcc\x03\n\x06Result\x12\x0f\n\x07\x63\x61v_key\x18\x01 \x01(\t\x12\x13\n\x0b\x63\x61v_concept\x18\x02 \x01(\t\x12\x18\n\x10negative_concept\x18\x03 \x01(\t\x12\x14\n\x0ctarget_class\x18\x04 \x01(\t\x12:\n\x0e\x63\x61v_accuracies\x18\x05 \x01(\x0b\x32\".tcav_results.Result.CAVaccuracies\x12\x0c\n\x04i_up\x18\x06 \x01(\x02\x12%\n\x1dval_directional_dirs_abs_mean\x18\x07 \x01(\x02\x12!\n\x19val_directional_dirs_mean\x18\x08 \x01(\x02\x12 \n\x18val_directional_dirs_std\x18\t \x01(\x02\x12\x1c\n\x14val_directional_dirs\x18\n \x03(\x02\x12\x0c\n\x04note\x18\x0b \x01(\t\x12\r\n\x05\x61lpha\x18\x0c \x01(\x02\x12\x12\n\nbottleneck\x18\r \x01(\t\x1ag\n\rCAVaccuracies\x12\x1d\n\x15positive_set_accuracy\x18\x01 \x01(\x02\x12\x1d\n\x15negative_set_accuracy\x18\x02 \x01(\x02\x12\x18\n\x10overall_accuracy\x18\x03 \x01(\x02\"0\n\x07Results\x12%\n\x07results\x18\x01 \x03(\x0b\x32\x14.tcav_results.Result')
+  serialized_pb=_b('\n\x1atcav_results/results.proto\x12\x0ctcav_results\"\xcc\x03\n\x06Result\x12\x0f\n\x07\x63\x61v_key\x18\x01 \x01(\t\x12\x13\n\x0b\x63\x61v_concept\x18\x02 \x01(\t\x12\x18\n\x10negative_concept\x18\x03 \x01(\t\x12\x14\n\x0ctarget_class\x18\x04 \x01(\x05\x12:\n\x0e\x63\x61v_accuracies\x18\x05 \x01(\x0b\x32\".tcav_results.Result.CAVaccuracies\x12\x0c\n\x04i_up\x18\x06 \x01(\x02\x12%\n\x1dval_directional_dirs_abs_mean\x18\x07 \x01(\x02\x12!\n\x19val_directional_dirs_mean\x18\x08 \x01(\x02\x12 \n\x18val_directional_dirs_std\x18\t \x01(\x02\x12\x1c\n\x14val_directional_dirs\x18\n \x03(\x02\x12\x0c\n\x04note\x18\x0b \x01(\t\x12\r\n\x05\x61lpha\x18\x0c \x01(\x02\x12\x12\n\nbottleneck\x18\r \x01(\t\x1ag\n\rCAVaccuracies\x12\x1d\n\x15positive_set_accuracy\x18\x01 \x01(\x02\x12\x1d\n\x15negative_set_accuracy\x18\x02 \x01(\x02\x12\x18\n\x10overall_accuracy\x18\x03 \x01(\x02\"0\n\x07Results\x12%\n\x07results\x18\x01 \x03(\x0b\x32\x14.tcav_results.Result')
 )
 
 
@@ -100,8 +100,8 @@ _RESULT = _descriptor.Descriptor(
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='target_class', full_name='tcav_results.Result.target_class', index=3,
-      number=4, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
+      number=4, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),

--- a/tcav/utils.py
+++ b/tcav/utils.py
@@ -228,7 +228,7 @@ def print_results(results, random_counterpart=None, random_concepts=None, num_ra
 
 def make_dir_if_not_exists(directory):
   if not tf.io.gfile.exists(directory):
-    tf.io.gfile.mkdir(directory)
+    tf.io.gfile.makedirs(directory)
 
 
 def result_to_proto(result):

--- a/tcav/utils.py
+++ b/tcav/utils.py
@@ -17,7 +17,7 @@ limitations under the License.
 from scipy.stats import ttest_ind
 import numpy as np
 import tensorflow as tf
-from tcav_results.results_pb2 import Result, Results
+from tcav.tcav_results.results_pb2 import Result, Results
 
 _KEYS = [
     "cav_key", "cav_concept", "negative_concept", "target_class", "i_up",
@@ -227,8 +227,8 @@ def print_results(results, random_counterpart=None, random_concepts=None, num_ra
 
 
 def make_dir_if_not_exists(directory):
-  if not tf.gfile.Exists(directory):
-    tf.gfile.MakeDirs(directory)
+  if not tf.io.gfile.exists(directory):
+    tf.io.gfile.mkdir(directory)
 
 
 def result_to_proto(result):

--- a/tcav/utils_test.py
+++ b/tcav/utils_test.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from tensorflow.python.platform import googletest
-from tcav_results.results_pb2 import Result, Results
+from tcav.tcav_results.results_pb2 import Result, Results
 from tcav.utils import flatten, process_what_to_run_expand, process_what_to_run_concepts, process_what_to_run_randoms, results_to_proto
 
 


### PR DESCRIPTION
A few updates to get UTs to pass immediately upon cloning of repo and installation through requirements.txt

- Update versions in requiremnts.txt to better match reality
- Switch from tf.Gfile to tf.io.gfile, due to deprecation
- Change one flag name in cav_test due to conflict with an externally-defined flag
- Correct, complete HParams in cav_test.py
- Correct, complete import path to tcav_results in utils.py and utils_test.py
- Rebuilt pre-compiled results_pb2.py from proto due to recent change to proto in another PR
- Ensure run_paralllel setting in TCAV extends to compute_tcav_score call, instead of always running this step in parallel regardless of what user provides to .run()