### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/tcav/model.py
+++ b/tcav/model.py
@@ -108,7 +108,7 @@ class ModelWrapper(six.with_metaclass(ABCMeta, object)):
     except Exception as e:
       template = 'An exception of type {0} occurred ' \
                  'when trying to load model from {1}. ' \
-                 'Arguments:\n{2!r}'
+                 'Args:\n{2!r}'
       tf.compat.v1.logging.warn(template.format(type(e).__name__, model_path, e.args))
 
   def _find_ends_and_bottleneck_tensors(self, node_dict):


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue with the TensorFlow codebase: inconsistent use of `Args:` and `Arguments:` in its docstrings. It is easy enough to extend my parsers to support both variants, however it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the codebase.

PS: For related PRs, see tensorflow/tensorflow/pull/45420