### PR TITLE
Fix thread explosion

### DIFF
--- a/tcav/activation_generator.py
+++ b/tcav/activation_generator.py
@@ -189,6 +189,7 @@ class ImageActivationGenerator(ActivationGeneratorBase):
       imgs = pool.map(
           lambda filename: self.load_image_from_file(filename, shape),
           filenames[:max_imgs])
+      pool.close()
       imgs = [img for img in imgs if img is not None]
       if len(imgs) <= 1:
         raise ValueError(

--- a/tcav/tcav.py
+++ b/tcav/tcav.py
@@ -95,6 +95,7 @@ class TCAV(object):
               mymodel, np.expand_dims(class_acts[i], 0),
               cav, concept, class_id, examples[i]),
           range(len(class_acts)))
+      pool.close()
       return sum(directions) / float(len(class_acts))
     else:
       for i in range(len(class_acts)):
@@ -218,6 +219,7 @@ class TCAV(object):
           self.params), 1):
         tf.compat.v1.logging.info('Finished running param %s of %s' % (i, len(self.params)))
         results.append(res)
+      pool.close()
     else:
       for i, param in enumerate(self.params):
         tf.compat.v1.logging.info('Running param %s of %s' % (i, len(self.params)))


### PR DESCRIPTION
- when running TCAV in environment using Python version 3.6.9, number
  of active threads can explode when run 'load_images_from_files(...)'
  of activation_generator in parallel (which is default), this might
  raise an exception, when the OS prevents starting new threads!
- this problem does not occur with Python version 3.8.8 and 3.9.4,
  however the current official Tensorflow Docker image uses Python 3.6.9
- fix: close thread pool appropriately to release resources