### PR TITLE
Fix relative cav

### DIFF
--- a/tcav/activation_generator.py
+++ b/tcav/activation_generator.py
@@ -69,24 +69,25 @@ class ActivationGeneratorBase(ActivationGeneratorInterface):
     for concept in concepts:
       if concept not in acts:
         acts[concept] = {}
+
       for bottleneck_name in bottleneck_names:
-        acts_path = os.path.join(self.acts_dir, 'acts_{}_{}'.format(
-            concept, bottleneck_name)) if self.acts_dir else None
+        acts_path = os.path.join(self.acts_dir, f'acts_{concept}_{bottleneck_name}') if self.acts_dir else None
+
         if acts_path and tf.io.gfile.exists(acts_path):
+          # load activations from file
           with tf.io.gfile.GFile(acts_path, 'rb') as f:
-            acts[concept][bottleneck_name] = np.load(
-                f, allow_pickle=True).squeeze()
-            tf.compat.v1.logging.info('Loaded {} shape {}'.format(
-                acts_path, acts[concept][bottleneck_name].shape))
+            acts[concept][bottleneck_name] = np.load(f, allow_pickle=True).squeeze()
+            tf.compat.v1.logging.info(f'Loaded {acts_path} shape {acts[concept][bottleneck_name].shape}')
         else:
-          acts[concept][bottleneck_name] = self.get_activations_for_concept(
-              concept, bottleneck_name)
+          # compute and save activations
+          acts[concept][bottleneck_name] = self.get_activations_for_concept(concept, bottleneck_name)
+
           if acts_path:
-            tf.compat.v1.logging.info(
-                '{} does not exist, Making one...'.format(acts_path))
+            tf.compat.v1.logging.info(f'{acts_path} does not exist, Making one...')
             tf.io.gfile.mkdir(os.path.dirname(acts_path))
             with tf.io.gfile.GFile(acts_path, 'w') as f:
               np.save(f, acts[concept][bottleneck_name], allow_pickle=False)
+
     return acts
 
 

--- a/tcav/tcav_test.py
+++ b/tcav/tcav_test.py
@@ -225,12 +225,9 @@ class TcavTest(googletest.TestCase):
     self.assertEqual(sorted(my_relative_tcav.all_concepts),
                      sorted(['t1', 'c1', 'c2', 'c3']))
     self.assertEqual(sorted(my_relative_tcav.pairs_to_test),
-                     sorted([('t1',['c1', 'c2']),
-                             ('t1',['c1', 'c3']),
-                             ('t1',['c2', 'c1']),
-                             ('t1',['c2', 'c3']),
-                             ('t1',['c3', 'c1']),
-                             ('t1',['c3', 'c2']),
+                     sorted([('t1',['c1', 'c2:c3']),
+                             ('t1',['c2', 'c1:c3']),
+                             ('t1',['c3', 'c1:c2']),
                              ]))
 
   def test_get_params(self):

--- a/tcav/tcav_test.py
+++ b/tcav/tcav_test.py
@@ -221,8 +221,7 @@ class TcavTest(googletest.TestCase):
                             self.act_gen,
                             [self.hparams['alpha']],
                             random_concepts=concepts_relative)
-    self.mytcav_random_counterpart._process_what_to_run_expand(
-        num_random_exp=2, random_concepts=concepts_relative)
+
     self.assertEqual(sorted(my_relative_tcav.all_concepts),
                      sorted(['t1', 'c1', 'c2', 'c3']))
     self.assertEqual(sorted(my_relative_tcav.pairs_to_test),

--- a/tcav/utils.py
+++ b/tcav/utils.py
@@ -26,6 +26,7 @@ _KEYS = [
 ]
 
 MAX_RANDOM_EXPERIMENTS = 100
+CONCEPT_SEPARATOR = ':'
 
 
 def create_session(timeout=10000, interactive=True):
@@ -56,7 +57,8 @@ def flatten(nested_list):
 def process_what_to_run_expand(pairs_to_test,
                                random_counterpart=None,
                                num_random_exp=100,
-                               random_concepts=None):
+                               random_concepts=None,
+                               relative_tcav=False):
   """Get concept vs. random or random vs. random pairs to run.
 
     Given set of target, list of concept pairs, expand them to include
@@ -95,17 +97,30 @@ def process_what_to_run_expand(pairs_to_test,
           new_pairs_to_test_t.append((target, [concept_set[0], get_random_concept(i)]))
         i += 1
     elif len(concept_set) > 1:
-      new_pairs_to_test_t.append((target, concept_set))
+      if relative_tcav:
+        for concept in concept_set:
+          negative_set = CONCEPT_SEPARATOR.join(np.setdiff1d(concept_set, concept))  # c2:c3:... excluding c_i where i=j
+          new_pairs_to_test_t.append((target, [concept, negative_set]))
+      else:
+        new_pairs_to_test_t.append((target, concept_set))
     else:
       tf.compat.v1.logging.info('PAIR NOT PROCESSED')
     new_pairs_to_test.extend(new_pairs_to_test_t)
 
-  all_concepts = list(set(flatten([cs + [tc] for tc, cs in new_pairs_to_test])))
+  if relative_tcav:
+    all_concepts = []
+    for tc, cs in new_pairs_to_test:
+      all_concepts.append([tc])
+      for c in cs:
+        all_concepts.append(c.split(':'))
+    all_concepts = list(set(flatten(all_concepts)))
+  else:
+    all_concepts = list(set(flatten([cs + [tc] for tc, cs in new_pairs_to_test])))
 
   return all_concepts, new_pairs_to_test
 
 
-def process_what_to_run_concepts(pairs_to_test):
+def process_what_to_run_concepts(pairs_to_test, relative_tcav=False):
   """Process concepts and pairs to test.
 
   Args:
@@ -124,10 +139,15 @@ def process_what_to_run_concepts(pairs_to_test):
   """
 
   pairs_for_sstesting = []
-  # prepare pairs for concpet vs random.
-  for pair in pairs_to_test:
-    for concept in pair[1]:
-      pairs_for_sstesting.append([pair[0], [concept]])
+  if relative_tcav:
+    # keep things as is
+    return pairs_to_test
+  else:
+    # prepare pairs for concpet vs random.
+    for target, concept_set in pairs_to_test:
+      for concept in concept_set:
+        pairs_for_sstesting.append([target, [concept]])
+
   return pairs_for_sstesting
 
 

--- a/tcav/utils.py
+++ b/tcav/utils.py
@@ -25,6 +25,8 @@ _KEYS = [
     "val_directional_dirs_std", "note", "alpha", "bottleneck"
 ]
 
+MAX_RANDOM_EXPERIMENTS = 100
+
 
 def create_session(timeout=10000, interactive=True):
   """Create a tf session for the model.
@@ -87,17 +89,15 @@ def process_what_to_run_expand(pairs_to_test,
     # if only one element was given, this is to test with random.
     if len(concept_set) == 1:
       i = 0
-      while len(new_pairs_to_test_t) < min(100, num_random_exp):
+      while len(new_pairs_to_test_t) < min(MAX_RANDOM_EXPERIMENTS, num_random_exp):  # fixme: why max 100? magic number
         # make sure that we are not comparing the same thing to each other.
-        if concept_set[0] != get_random_concept(
-            i) and random_counterpart != get_random_concept(i):
-          new_pairs_to_test_t.append(
-              (target, [concept_set[0], get_random_concept(i)]))
+        if concept_set[0] != get_random_concept(i) and random_counterpart != get_random_concept(i):
+          new_pairs_to_test_t.append((target, [concept_set[0], get_random_concept(i)]))
         i += 1
     elif len(concept_set) > 1:
       new_pairs_to_test_t.append((target, concept_set))
     else:
-      tf.compat.v1.logging.info('PAIR NOT PROCCESSED')
+      tf.compat.v1.logging.info('PAIR NOT PROCESSED')
     new_pairs_to_test.extend(new_pairs_to_test_t)
 
   all_concepts = list(set(flatten([cs + [tc] for tc, cs in new_pairs_to_test])))

--- a/tcav/utils_test.py
+++ b/tcav/utils_test.py
@@ -16,7 +16,7 @@ from __future__ import division
 from __future__ import print_function
 from tensorflow.python.platform import googletest
 from tcav.tcav_results.results_pb2 import Result, Results
-from tcav.utils import flatten, process_what_to_run_expand, process_what_to_run_concepts, process_what_to_run_randoms, results_to_proto
+from tcav.utils import flatten, process_what_to_run_expand, process_what_to_run_concepts, process_what_to_run_randoms, results_to_proto, MAX_RANDOM_EXPERIMENTS
 
 
 class UtilsTest(googletest.TestCase):
@@ -41,6 +41,21 @@ class UtilsTest(googletest.TestCase):
         sorted([('t1', ['c1', 'random500_0']), ('t1', ['c1', 'random500_1']),
                 ('t1', ['c2', 'random500_0']),
                 ('t1', ['c2', 'random500_1'])]))
+
+  def test_process_what_to_run_expand_max_experiments(self):
+    num_random_exp = MAX_RANDOM_EXPERIMENTS + 2  # just add some number to be bigger than max value
+    all_concepts, pairs_to_test = process_what_to_run_expand(
+        self.pair_to_test_one_concept,
+        num_random_exp=num_random_exp)
+
+    concepts = ['c1', 'c2']
+    expected_max_size = MAX_RANDOM_EXPERIMENTS
+    self.assertEqual(
+        sorted(all_concepts),
+        sorted(['t1'] + concepts + [f'random500_{i}' for i in range(expected_max_size)]))
+
+    # expect max experiments =  num_concepts * expected_max_size
+    self.assertEqual(len(pairs_to_test), len(concepts*MAX_RANDOM_EXPERIMENTS))
 
   def test_process_what_to_run_expand_specify_dirs(self):
     all_concepts, pairs_to_test = process_what_to_run_expand(


### PR DESCRIPTION
- the paper states in section 3.6 for relative tcav, construct a positive and negative set, e.g., for concepts P_dot, P_stripe, P_mesh this would look like, P_stripe (positive) and {P_dot U p_mesh} (negative). However, the code was giving sets like, P_stripe (pos), P_dot (neg). Now, the complement set is used for relative tcav as described in the paper.
- when computing relative tcav, plot function failed because concepts are also 'random' concepts and is_random_concept(concept) is always true, therefore. Now, plot for relative tcav handles 'random' concepts correctly.

Hope I did understand the paper correctly and gave a proper fix.